### PR TITLE
[feat] Advisor can edit project fields on parameters tab

### DIFF
--- a/recoco/apps/projects/forms.py
+++ b/recoco/apps/projects/forms.py
@@ -57,7 +57,7 @@ class ProjectForm(forms.ModelForm):
     """Form for updating the base information of a project"""
 
     postcode = forms.CharField(max_length=5, required=False, label="Code Postal")
-    insee = forms.CharField(max_length=5, required=False, label="Code Insee")
+    insee = forms.CharField(max_length=5, required=False, label="Commune")
 
     class Meta:
         model = models.Project
@@ -69,6 +69,10 @@ class ProjectForm(forms.ModelForm):
             "description",
         ]
 
+        labels = {
+            "location": "Adresse",
+            "description": "Contexte du projet",
+        }
 
 class DocumentUploadForm(forms.ModelForm):
     class Meta:

--- a/recoco/apps/projects/models.py
+++ b/recoco/apps/projects/models.py
@@ -66,6 +66,7 @@ ADVISOR_PERMISSIONS = [
     "projects.manage_documents",
     "projects.use_surveys",
     "projects.view_surveys",
+    "projects.change_project",
     "projects.change_location",
 ]
 

--- a/recoco/apps/projects/templates/projects/project/administration_panel.html
+++ b/recoco/apps/projects/templates/projects/project/administration_panel.html
@@ -48,7 +48,7 @@
           <div class="row mb-3">
             <div class="col">
               <label class="mb-2 text-info-custom text-grey-dark"
-                     for="input-project-address">Adresse</label>
+                     for="input-project-address">{{ project_form.location.label }}</label>
               <input type="text"
                      class="py-3 placeholder-grey form-control {% if project_form.location.errors %}is-invalid{% endif %}"
                      id="input-project-address"
@@ -62,7 +62,7 @@
           <div class="row mb-3">
             <div class="col">
               <label class="text-info-custom text-grey-dark"
-                     for="input-project-description">Contexte du projet</label>
+                     for="input-project-description">{{ project_form.description.label }}</label>
               <textarea maxlength="500"
                         class="placeholder-grey form-control {% if project_form.description.errors %}is-invalid{% endif %}"
                         style="height: 100px"
@@ -93,7 +93,7 @@
               </div>
             </div>
             <div class="mb-3 col-auto">
-              <label class="text-info-custom text-grey-dark" for="input-project-address">Commune</label>
+              <label class="text-info-custom text-grey-dark" for="input-project-address">{{ project_form.insee.label }}</label>
               <select required
                       :style="cities && cities.length == 0 && postal ? 'background-color:#e9ecef;pointer-events:none;padding: 12px 10px; border-radius: 0.25rem;min-width: 170px;padding-right: 30px;' : 'padding: 12px 10px; border-radius: 0.25rem;min-width: 170px;padding-right: 30px;' "
                       style=""

--- a/recoco/apps/projects/tests/test_administration.py
+++ b/recoco/apps/projects/tests/test_administration.py
@@ -9,6 +9,7 @@ created: 2022-12-26 11:54:56 CEST
 
 
 import pytest
+from actstream.models import action_object_stream
 from django.contrib.auth import models as auth_models
 from django.contrib.sites import models as site_models
 from django.contrib.sites.shortcuts import get_current_site
@@ -18,12 +19,15 @@ from model_bakery import baker
 from model_bakery.recipe import Recipe
 from notifications.signals import notify
 from pytest_django.asserts import assertContains, assertRedirects
+
+from recoco import verbs
 from recoco.apps.communication import api as communication_api
 from recoco.apps.geomatics import models as geomatics
 from recoco.apps.invites import models as invites_models
 from recoco.apps.projects import models as projects_models
 from recoco.apps.projects.utils import assign_advisor, assign_collaborator
 from recoco.utils import login
+
 
 from .. import models
 
@@ -78,6 +82,14 @@ def test_project_update_when_missing_commune(request, client):
 
     assert response.status_code == 302
 
+    actions = action_object_stream(project)
+    assert actions.count() == 1
+    assert actions[0].verb.startswith(verbs.Project.EDITED[:20])
+    assert "nom" in actions[0].verb
+    assert "adresse" in actions[0].verb
+    assert "contexte" in actions[0].verb
+    assert "code postal" not in actions[0].verb
+    assert "commune" not in actions[0].verb
 
 @pytest.mark.django_db
 def test_project_update_commune(request, client):
@@ -108,6 +120,16 @@ def test_project_update_commune(request, client):
 
     project = models.Project.objects.get(id=project.pk)
     assert project.commune == new_commune
+
+
+    actions = action_object_stream(project)
+    assert actions.count() == 1
+    assert actions[0].verb.startswith(verbs.Project.EDITED[:20])
+    assert "nom" in actions[0].verb
+    assert "adresse" in actions[0].verb
+    assert "contexte" in actions[0].verb
+    assert "code postal" in actions[0].verb
+    assert "commune" in actions[0].verb
 
 
 @pytest.mark.django_db

--- a/recoco/apps/projects/tests/test_administration.py
+++ b/recoco/apps/projects/tests/test_administration.py
@@ -84,12 +84,12 @@ def test_project_update_when_missing_commune(request, client):
 
     actions = action_object_stream(project)
     assert actions.count() == 1
-    assert actions[0].verb.startswith(verbs.Project.EDITED[:20])
-    assert "nom" in actions[0].verb
-    assert "adresse" in actions[0].verb
-    assert "contexte" in actions[0].verb
-    assert "code postal" not in actions[0].verb
-    assert "commune" not in actions[0].verb
+    assert actions[0].verb == verbs.Project.EDITED
+    assert "nom" in actions[0].description
+    assert "adresse" in actions[0].description
+    assert "contexte" in actions[0].description
+    assert "code postal" not in actions[0].description
+    assert "commune" not in actions[0].description
 
 @pytest.mark.django_db
 def test_project_update_commune(request, client):
@@ -124,12 +124,12 @@ def test_project_update_commune(request, client):
 
     actions = action_object_stream(project)
     assert actions.count() == 1
-    assert actions[0].verb.startswith(verbs.Project.EDITED[:20])
-    assert "nom" in actions[0].verb
-    assert "adresse" in actions[0].verb
-    assert "contexte" in actions[0].verb
-    assert "code postal" in actions[0].verb
-    assert "commune" in actions[0].verb
+    assert actions[0].verb == verbs.Project.EDITED
+    assert "nom" in actions[0].description
+    assert "adresse" in actions[0].description
+    assert "contexte" in actions[0].description
+    assert "code postal" in actions[0].description
+    assert "commune" in actions[0].description
 
 
 @pytest.mark.django_db

--- a/recoco/apps/projects/views/administration.py
+++ b/recoco/apps/projects/views/administration.py
@@ -93,8 +93,9 @@ def project_administration(request, project_id):
             # get list of edited fields to track action
             edited_fields = []
             for field_name, submitted_value in form.cleaned_data.items():
-                # get commune attr for related fields
+                # Those fields aren't in form.initial because it is a ModelForm for the Project model.
                 if field_name in ["postcode", "insee"]:
+                    # get commune attr for related fields
                     if project.commune:
                         original_value = getattr(project.commune, "postal" if field_name == "postcode" else field_name)
                     else:

--- a/recoco/apps/projects/views/administration.py
+++ b/recoco/apps/projects/views/administration.py
@@ -90,6 +90,28 @@ def project_administration(request, project_id):
 
         form = forms.ProjectForm(request.POST, instance=project)
         if form.is_valid():
+            # get list of edited fields to track action
+            edited_fields = []
+            for field_name, submitted_value in form.cleaned_data.items():
+                # get commune attr for related fields
+                if field_name in ["postcode", "insee"]:
+                    if project.commune:
+                        original_value = getattr(project.commune, "postal" if field_name == "postcode" else field_name)
+                    else:
+                        original_value = ""
+                else :
+                    original_value = form.initial[field_name]
+                if str(original_value) != str(submitted_value):
+                    edited_fields.append(form.fields[field_name].label.lower().replace(" du projet", ""))
+
+            if edited_fields:
+                action.send(
+                    request.user,
+                    verb=verbs.Project.EDITED % " / ".join(edited_fields),
+                    action_object=project,
+                    target=project,
+                )
+            
             instance = form.save(commit=False)
 
             try:

--- a/recoco/apps/projects/views/administration.py
+++ b/recoco/apps/projects/views/administration.py
@@ -106,11 +106,10 @@ def project_administration(request, project_id):
                     edited_fields.append(form.fields[field_name].label.lower().replace(" du projet", ""))
 
             if edited_fields:
-                plural = "s" if len(edited_fields) > 1 else ""
                 action.send(
                     request.user,
                     verb=verbs.Project.EDITED,
-                    description=f"Le{plural} champ{plural} modifié{plural} : {' / '.join(edited_fields)}",
+                    description=" / ".join(edited_fields),
                     action_object=project,
                     target=project,
                 )

--- a/recoco/apps/projects/views/administration.py
+++ b/recoco/apps/projects/views/administration.py
@@ -105,9 +105,11 @@ def project_administration(request, project_id):
                     edited_fields.append(form.fields[field_name].label.lower().replace(" du projet", ""))
 
             if edited_fields:
+                plural = "s" if len(edited_fields) > 1 else ""
                 action.send(
                     request.user,
-                    verb=verbs.Project.EDITED % " / ".join(edited_fields),
+                    verb=verbs.Project.EDITED,
+                    description=f"Le{plural} champ{plural} modifié{plural} : {' / '.join(edited_fields)}",
                     action_object=project,
                     target=project,
                 )

--- a/recoco/templates/default_site/actstream/action.html
+++ b/recoco/templates/default_site/actstream/action.html
@@ -52,6 +52,11 @@
                   {% endif %}
                 </div>
               {% endif %}
+              {% if action.description %}
+                <div class="d-inline-block">
+                  {{ action.description }}
+                </div>
+              {% endif %}
             {% endif %}
           </span>
         </span>

--- a/recoco/verbs.py
+++ b/recoco/verbs.py
@@ -67,7 +67,7 @@ class Project:
     SET_INACTIVE = "a mis en pause le projet"
     SET_ACTIVE = "a réactivé le projet"
 
-    EDITED = "a modifé le.s champ.s du projet"
+    EDITED = "a modifé les informations du projet"
 
 
 class Survey:

--- a/recoco/verbs.py
+++ b/recoco/verbs.py
@@ -67,6 +67,8 @@ class Project:
     SET_INACTIVE = "a mis en pause le projet"
     SET_ACTIVE = "a réactivé le projet"
 
+    EDITED = "a modifé le.s champ.s %s du projet"
+
 
 class Survey:
     STARTED = "a démarré l'état des lieux"

--- a/recoco/verbs.py
+++ b/recoco/verbs.py
@@ -67,7 +67,7 @@ class Project:
     SET_INACTIVE = "a mis en pause le projet"
     SET_ACTIVE = "a réactivé le projet"
 
-    EDITED = "a modifé le.s champ.s %s du projet"
+    EDITED = "a modifé le.s champ.s du projet"
 
 
 class Survey:


### PR DESCRIPTION
Advisors can now edit project information

![image](https://github.com/betagouv/recommandations-collaboratives/assets/17601807/a8d61358-cae1-40fc-865f-e701a68b7c69)

And actions are tracked : 

![image](https://github.com/betagouv/recommandations-collaboratives/assets/17601807/1300af6a-a8ef-4b99-a604-63645f49f2b8)

Warning : remember to update permissions after deployment (`python manage.py update_permissions`)
