### PR TITLE
fix: an ordered list followed by a bullet list results in a large ordered list

### DIFF
--- a/recoco/settings/common.py
+++ b/recoco/settings/common.py
@@ -239,6 +239,7 @@ MAGICAUTH_TOKEN_DURATION_SECONDS = 60 * 60 * 24 * 3
 MARKDOWNX_MARKDOWN_EXTENSIONS = [
     "markdown.extensions.extra",
     "markdown_link_attr_modifier",
+    "sane_lists",  # https://python-markdown.github.io/extensions/sane_lists/
 ]
 
 MARKDOWNX_MARKDOWN_EXTENSION_CONFIGS = {


### PR DESCRIPTION

When editing :
![screenshot-localhost_8000-2024 03 29-09_43_18](https://github.com/betagouv/recommandations-collaboratives/assets/17601807/ff9cea04-29f6-4980-949f-68082dc5145d)

Before fix : 

![screenshot-localhost_8000-2024 03 29-09_43_32](https://github.com/betagouv/recommandations-collaboratives/assets/17601807/ddbe51ad-c80e-4476-adf8-6ce484811abb)

After fix : 

![screenshot-localhost_8000-2024 03 29-10_22_48](https://github.com/betagouv/recommandations-collaboratives/assets/17601807/da509375-2713-4c2e-abea-9ae87b4ddcce)

The markdown module has [an extension "sane list"](https://python-markdown.github.io/extensions/sane_lists/) to fix this behavior, and markdownx allows to enable it with setting  `MARKDOWNX_MARKDOWN_EXTENSIONS`.