### PR TITLE
fix: use same get_or_create to avoid duplicate organization

### DIFF
--- a/recoco/apps/addressbook/views.py
+++ b/recoco/apps/addressbook/views.py
@@ -30,7 +30,7 @@ def organization_create(request):
         if form.is_valid():
             name = form.cleaned_data.get("name")
             departments = form.cleaned_data.get("departments")
-            organization, _ = models.Organization.on_site.get_or_create(name=name)
+            organization = models.Organization.get_or_create(name=name)
             organization.sites.add(request.site)
             organization.departments.add(*departments)
             organization.save()


### PR DESCRIPTION
In the address book section, it is possible to add a new organization.

The organization suggestion only searches the current site, and if you submitted anyway, a duplicate organization will be created, even if the organization of the same name already exists on another site.

This behavior creates duplicate organization and errors during project creation (/onboarding/prefill).

Solution :
Just use Organization.get_or_create() instead Organization.on_site.get_or_create().