### PR TITLE
[hotfix] override link style

### DIFF
--- a/recoco/apps/home/static/home/css/dsfr/custom-dsfr.scss
+++ b/recoco/apps/home/static/home/css/dsfr/custom-dsfr.scss
@@ -27,6 +27,10 @@
   // --display-spacing: 0 0 2rem;
 }
 
+a {
+  text-decoration: none;
+}
+
 a.fr-btn {
   &:hover {
     &:not(.fr-btn--secondary) {


### PR DESCRIPTION
Il s'agit de :
- [X] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Ajout d'une règle CSS permettant d'écraser le style sousligné par défaut
<img width="1499" alt="Capture d’écran 2024-04-09 à 12 05 53" src="https://github.com/betagouv/recommandations-collaboratives/assets/10596045/b8f6e84a-285e-4c9a-bb59-a5c5164770dc">

## Checklist d'acceptation de revue de code
- [X] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [X] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [X] La gestion du multi-portail a été prise en compte
- [X] L'accessibilité a été prise en compte
- [X] Pre-commit est configuré et a été lancé
- [X] Des tests couvrant le code changé ont été ajoutés/modifiés
- [X] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
