### PR TITLE
fix: Ajout des paramètres manquant à l'invitation lors de la création d'un projet par un conseiller

### DIFF
--- a/recoco/apps/onboarding/views.py
+++ b/recoco/apps/onboarding/views.py
@@ -345,7 +345,11 @@ def invite_user_to_project(
         template_name=communication_constants.TPL_SHARING_INVITATION,
         recipients=[{"email": user.email}],
         params={
-            "sender": {"email": request.user.email},
+            "sender": {
+                "first_name": request.user.first_name,
+                "last_name": request.user.last_name,
+                "email": request.user.email
+            },
             "message": invite.message,
             "invite_url": build_absolute_url(
                 invite.get_absolute_url(),


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

Le template de mail d'invitation sur un projet a besoin du prénom et du nom.

=> https://trello.com/c/Ee9NM9Td

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
