### PR TITLE
feat: add api endpoint to mark all notifications as read for a user

### DIFF
--- a/recoco/apps/home/rest.py
+++ b/recoco/apps/home/rest.py
@@ -1,14 +1,37 @@
+from django.http import Http404
+from notifications import models as notifications_models
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from rest_framework import status
 
 
+class UserNotificationsMarkOneAsRead(APIView):
+
+    permission_classes = [IsAuthenticated]
+
+    def patch(self, request, pk):
+        try:
+            notification = request.user.notifications.get(pk=pk)
+        except notifications_models.Notification.DoesNotExist:
+            raise Http404
+
+        count = 0
+        is_hijacked = getattr(request.user, "is_hijacked", False)
+
+        if not is_hijacked:
+            if notification.unread:
+                count = 1
+                notification.mark_as_read()
+
+        return Response({"marked_as_read": count}, status=status.HTTP_200_OK)
+
+
 class UserNotificationsMarkAllAsRead(APIView):
 
     permission_classes = [IsAuthenticated]
 
-    def post(self, request, *args, **kwargs):
+    def patch(self, request, *args, **kwargs):
         count = 0
         is_hijacked = getattr(request.user, "is_hijacked", False)
 

--- a/recoco/apps/home/rest.py
+++ b/recoco/apps/home/rest.py
@@ -1,0 +1,21 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from rest_framework import status
+
+
+class UserNotificationsMarkAllAsRead(APIView):
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, *args, **kwargs):
+        count = 0
+        is_hijacked = getattr(request.user, "is_hijacked", False)
+
+        if not is_hijacked:
+            count = request.user.notifications.unread().mark_all_as_read()
+
+        return Response({"marked_as_read": count}, status=status.HTTP_200_OK)
+
+
+# eof

--- a/recoco/apps/home/tests/test_rest.py
+++ b/recoco/apps/home/tests/test_rest.py
@@ -1,0 +1,40 @@
+import pytest
+
+from django.contrib.auth import models as auth_models
+from django.contrib.sites.shortcuts import get_current_site
+from django.urls import reverse
+from model_bakery import baker
+from notifications.signals import notify
+from rest_framework.test import APIClient
+
+from recoco.apps.projects import models as project_models
+
+
+@pytest.mark.django_db
+def test_user_notifications_mark_all_as_read(request):
+
+    site = get_current_site(request)
+    project = baker.make(project_models.Project, sites=[site])
+
+    user = baker.make(auth_models.User)
+    other_user = baker.make(auth_models.User)
+
+    for verb in ["a fake verb", "other fake verb"]:
+        notify.send(sender=user, recipient=user, verb=verb, target=project)
+        notify.send(sender=other_user, recipient=other_user, verb=verb, target=project)
+
+    assert user.notifications.unread().count() == 2
+    assert other_user.notifications.unread().count() == 2
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+    url = reverse("notifications-mark-all-as-read")
+    response = client.post(url)
+
+    assert response.status_code == 200
+    assert response.data["marked_as_read"] == 2
+    assert user.notifications.unread().count() == 0
+    assert other_user.notifications.unread().count() == 2
+
+
+# eof

--- a/recoco/rest_api/urls.py
+++ b/recoco/rest_api/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 
+from notifications import views as notifications_views
 from rest_framework import routers
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
@@ -100,6 +101,11 @@ api_urls = [
         "notifications/mark-all-as-read",
         home_rest.UserNotificationsMarkAllAsRead.as_view(),
         name="notifications-mark-all-as-read",
+    ),
+    path(
+        "notifications/unread_list",
+        notifications_views.live_unread_notification_list,
+        name="notifications-unread-list",
     ),
 ]
 

--- a/recoco/rest_api/urls.py
+++ b/recoco/rest_api/urls.py
@@ -1,14 +1,16 @@
 from django.urls import path
 
 from rest_framework import routers
+from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 from recoco.apps.addressbook import rest as addressbook_rest
 from recoco.apps.geomatics import rest as geomatics_rest
+from recoco.apps.home import rest as home_rest
 from recoco.apps.projects.views import rest as projects_rest
+from recoco.apps.resources import rest as resources_rest
 from recoco.apps.tasks.views import rest as tasks_rest
 from recoco.apps.training import rest as training_rest
-from recoco.apps.resources import rest as resources_rest
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+
 
 router = routers.DefaultRouter()
 
@@ -88,6 +90,11 @@ api_urls = [
         "challenges/<str:slug>/",
         training_rest.ChallengeView.as_view(),
         name="challenges-challenge",
+    ),
+    path(
+        "notifications/mark-all-as-read",
+        home_rest.UserNotificationsMarkAllAsRead.as_view(),
+        name="notifications-mark-all-as-read",
     ),
 ]
 

--- a/recoco/rest_api/urls.py
+++ b/recoco/rest_api/urls.py
@@ -92,6 +92,11 @@ api_urls = [
         name="challenges-challenge",
     ),
     path(
+        "notifications/mark-one-as-read/<int:pk>/",
+        home_rest.UserNotificationsMarkOneAsRead.as_view(),
+        name="notifications-mark-one-as-read",
+    ),
+    path(
         "notifications/mark-all-as-read",
         home_rest.UserNotificationsMarkAllAsRead.as_view(),
         name="notifications-mark-all-as-read",

--- a/recoco/urls.py
+++ b/recoco/urls.py
@@ -7,7 +7,6 @@ author  : raphael.marvie@beta.gouv.fr,guillaume.libersat@beta.gouv.fr
 created : 2021-05-26 11:29:25 CEST
 """
 
-import notifications.urls
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
@@ -35,7 +34,6 @@ urlpatterns = [
     path("accounts/", include("allauth.urls")),
     path("logout/", auth_views.LogoutView.as_view(), name="logout"),
     path("markdownx/", include("markdownx.urls")),
-    path("notifications/", include(notifications.urls, namespace="notifications")),
     path("hijack/", include("hijack.urls")),
     path("nimda/", admin.site.urls),
     path("cookies/", include("cookie_consent.urls")),


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

Ajout d'un endpoint d'API pour marquer toutes les notifications d'un utilisateur comme lues depuis le front.

resolves #423 
cc @Jeremy-Bojko 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
