### PR TITLE
Fix/adress project dropdown#417

### DIFF
--- a/recoco/apps/projects/utils.py
+++ b/recoco/apps/projects/utils.py
@@ -360,6 +360,7 @@ def refresh_user_projects_in_session(request, user):
             "name": p.name,
             "id": p.id,
             "location": p.location,
+            "commune": p.commune.name if p.commune else None,
             "inactive": bool(p.inactive_since),
             "actions_open": p.tasks.open().count(),
         }

--- a/recoco/templates/default_site/header/menu-top-secondary.html
+++ b/recoco/templates/default_site/header/menu-top-secondary.html
@@ -126,7 +126,7 @@
                                         <div class="d-flex flex-wrap justify-content-between align-items-center">
                                             <span class="text-break text-truncate">
                                                 <a class="stretched-link text-reset text-decoration-none"
-                                                   href="{% url "projects-project-detail" project.id %}">{{ project.name|capfirst }}</a>
+                                                   href="{% url "projects-project-detail" project.id %}">{{ project.commune|capfirst }}</a>
                                             </span>
                                             {% if project.inactive is False and project.actions_open > 0 %}
                                                 <div>
@@ -139,7 +139,7 @@
                                                 </div>
                                             {% endif %}
                                         </div>
-                                        <span class="text-secondary small text-break text-truncate">{{ project.commune|capfirst }}</span>
+                                        <span class="text-secondary small text-break text-truncate">{{ project.name|capfirst }}</span>
                                     </li>
                                 {% endfor %}
                                 {% if not is_switchtender %}

--- a/recoco/templates/default_site/header/menu-top-secondary.html
+++ b/recoco/templates/default_site/header/menu-top-secondary.html
@@ -139,7 +139,7 @@
                                                 </div>
                                             {% endif %}
                                         </div>
-                                        <span class="text-secondary small text-break text-truncate">{{ project.location|truncatechars:40|capfirst }}</span>
+                                        <span class="text-secondary small text-break text-truncate">{{ project.commune|capfirst }}</span>
                                     </li>
                                 {% endfor %}
                                 {% if not is_switchtender %}
@@ -172,10 +172,7 @@
         {% endif %}
         <!-- Methodology -->
         <!-- {% if not user.is_authenticated and not hide_methodology %}
-            <li style="margin-right: 35px;
-                       padding-bottom:20px;
-                       border-bottom:solid 2px transparent;
-                       {% if 'methodology' in url_name %}border-bottom:solid 2px #0063CB;{% endif %}">
+            <li style="margin-right: 35px; padding-bottom:20px; border-bottom:solid 2px transparent; {% if 'methodology' in url_name %}border-bottom:solid 2px #0063CB;{% endif %}">
                 <div class="btn-group">
                     <a href="{% url 'methodology' %}" class="nav-link link-dark">
                         <span class="me-2 ms-1 align-middle">Méthodologie</span>


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Dans le header > dropdown des projets l'affichage a été modifié pour que le du nom de la commune apparaisse en premier et que ce ne soit plus l'adresse du projet qui apparaisse.

<img width="446" alt="Capture d’écran 2024-05-31 à 17 20 24" src="https://github.com/betagouv/recommandations-collaboratives/assets/10596045/9013cbaf-0e15-4dd1-bbc1-bfc83c32833e">

close #417 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
