### PR TITLE
feat: extend the rest API

### DIFF
--- a/recoco/apps/projects/tests/test_rest.py
+++ b/recoco/apps/projects/tests/test_rest.py
@@ -282,6 +282,7 @@ def check_project_content(project, data):
         "private_message_count",
         "public_message_count",
         "recommendation_count",
+        "description",
     ]
     assert set(data.keys()) == set(expected)
 

--- a/recoco/apps/projects/views/rest.py
+++ b/recoco/apps/projects/views/rest.py
@@ -28,8 +28,8 @@ from recoco.utils import (
 from .. import models, signals
 from ..serializers import (
     ProjectForListSerializer,
-    ProjectSerializer,
     TopicSerializer,
+    UserProjectSerializer,
     UserProjectStatusForListSerializer,
     UserProjectStatusSerializer,
 )
@@ -56,7 +56,7 @@ class ProjectDetail(APIView):
             request.user, "view_project", p
         )
         context = {"request": request}
-        serializer = ProjectSerializer(p, context=context)
+        serializer = UserProjectSerializer(p, context=context)
         return Response(serializer.data)
 
     def patch(self, request, pk, format=None):
@@ -65,7 +65,7 @@ class ProjectDetail(APIView):
             request.user, "projects.change_location", p
         )  # need at least one write perm
         context = {"request": request, "view": self, "format": format}
-        serializer = ProjectSerializer(
+        serializer = UserProjectSerializer(
             p, context=context, data=request.data, partial=True
         )
         if serializer.is_valid():

--- a/recoco/apps/survey/serializers.py
+++ b/recoco/apps/survey/serializers.py
@@ -1,0 +1,66 @@
+from rest_framework import serializers
+
+from recoco.apps.home.serializers import UserSerializer
+
+from .models import Answer, Choice, Question, Session
+
+
+class ChoiceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Choice
+        fields = [
+            "id",
+            "value",
+            "text",
+        ]
+
+
+class QuestionSerializer(serializers.ModelSerializer):
+    choices = ChoiceSerializer(many=True)
+
+    class Meta:
+        model = Question
+        fields = [
+            "id",
+            "text",
+            "text_short",
+            "is_multiple",
+            "choices",
+        ]
+
+
+class AnswerSerializer(serializers.ModelSerializer):
+    question = QuestionSerializer()
+    updated_by = UserSerializer()
+    choices = ChoiceSerializer(many=True)
+    project = serializers.SerializerMethodField()
+
+    def get_project(self, obj: Answer):
+        return obj.session.project.id
+
+    class Meta:
+        model = Answer
+        fields = [
+            "id",
+            "created_on",
+            "updated_on",
+            "question",
+            "session",
+            "project",
+            "choices",
+            "values",
+            "comment",
+            "signals",
+            "updated_by",
+            "attachment",
+        ]
+
+
+class SessionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Session
+        fields = [
+            "id",
+            "survey",
+            "project",
+        ]

--- a/recoco/apps/survey/tests/test_rest.py
+++ b/recoco/apps/survey/tests/test_rest.py
@@ -1,0 +1,95 @@
+from unittest.mock import ANY
+
+import pytest
+from django.contrib.auth.models import User
+from django.contrib.sites.shortcuts import get_current_site
+from django.urls import reverse
+from model_bakery import baker
+
+from recoco.apps.projects import utils
+from recoco.apps.projects.models import Project
+from recoco.apps.survey.models import Answer, Question, Session
+
+
+@pytest.fixture
+def api_client():
+    from rest_framework.test import APIClient
+
+    return APIClient()
+
+
+@pytest.mark.django_db
+def test_session_view(request, api_client):
+    site = get_current_site(request)
+    project = baker.make(Project, sites=[site])
+    user = baker.make(User)
+    utils.assign_collaborator(user, project)
+
+    session = baker.make(Session, project=project)
+
+    api_client.force_authenticate(user=user)
+    response = api_client.get(
+        path=reverse("api-survey-sessions"),
+    )
+    assert response.status_code == 200
+    json_response = response.json()
+
+    assert json_response["count"] == 1
+    assert json_response["results"][0] == {
+        "id": session.id,
+        "project": session.project.id,
+        "survey": session.survey.id,
+    }
+
+
+@pytest.mark.django_db
+def test_session_answers_view(request, api_client):
+    site = get_current_site(request)
+    project = baker.make(Project, sites=[site])
+    user = baker.make(User)
+    utils.assign_collaborator(user, project)
+
+    session = baker.make(Session, project=project)
+    question = baker.make(
+        Question,
+        text="question text",
+        text_short="question text short",
+    )
+    answer = baker.make(
+        Answer,
+        session=session,
+        question=question,
+        comment="My comment",
+    )
+
+    api_client.force_authenticate(user=user)
+    response = api_client.get(
+        path=reverse(
+            "api-survey-session-answers",
+            kwargs={"session_id": session.id},
+        ),
+    )
+    assert response.status_code == 200
+    json_response = response.json()
+
+    assert json_response["count"] == 1
+    assert json_response["results"][0] == {
+        "id": answer.id,
+        "created_on": ANY,
+        "updated_on": ANY,
+        "question": {
+            "id": question.id,
+            "text": "question text",
+            "text_short": "question text short",
+            "is_multiple": False,
+            "choices": [],
+        },
+        "session": session.id,
+        "project": project.id,
+        "choices": [],
+        "values": [],
+        "comment": "My comment",
+        "signals": "",
+        "updated_by": None,
+        "attachment": None,
+    }

--- a/recoco/apps/survey/views/rest.py
+++ b/recoco/apps/survey/views/rest.py
@@ -1,0 +1,41 @@
+from rest_framework.generics import ListAPIView
+from rest_framework.pagination import LimitOffsetPagination
+from rest_framework.permissions import IsAuthenticated
+
+from recoco.apps.projects.models import Project
+
+from ..models import Answer, Session
+from ..serializers import AnswerSerializer, SessionSerializer
+
+
+class SessionView(ListAPIView):
+    serializer_class = SessionSerializer
+    permission_classes = [IsAuthenticated]
+    filterset_fields = ["project_id"]
+    pagination_class = LimitOffsetPagination
+
+    def get_queryset(self):
+        project_ids = Project.on_site.for_user(self.request.user).values_list(
+            "id", flat=True
+        )
+        return Session.objects.filter(project__in=project_ids)
+
+
+class SessionAnswersView(ListAPIView):
+    serializer_class = AnswerSerializer
+    permission_classes = [IsAuthenticated]
+    pagination_class = LimitOffsetPagination
+
+    def get_queryset(self):
+        project_ids = Project.on_site.for_user(self.request.user).values_list(
+            "id", flat=True
+        )
+        try:
+            session = Session.objects.get(
+                project__in=project_ids, id=self.kwargs["session_id"]
+            )
+            return session.answers.select_related("question").prefetch_related(
+                "choices"
+            )
+        except Session.DoesNotExist:
+            return Answer.objects.none()

--- a/recoco/rest_api/urls.py
+++ b/recoco/rest_api/urls.py
@@ -8,6 +8,7 @@ from recoco.apps.geomatics import rest as geomatics_rest
 from recoco.apps.home import rest as home_rest
 from recoco.apps.projects.views import rest as projects_rest
 from recoco.apps.resources import rest as resources_rest
+from recoco.apps.survey.views import rest as survey_rest
 from recoco.apps.tasks.views import rest as tasks_rest
 from recoco.apps.training import rest as training_rest
 
@@ -120,4 +121,17 @@ auth_urls = [
     ),
 ]
 
-urlpatterns = router.urls + api_urls + auth_urls
+survey_urls = [
+    path(
+        "survey/sessions/",
+        survey_rest.SessionView.as_view(),
+        name="api-survey-sessions",
+    ),
+    path(
+        "survey/sessions/<int:session_id>/answers/",
+        survey_rest.SessionAnswersView.as_view(),
+        name="api-survey-session-answers",
+    ),
+]
+
+urlpatterns = router.urls + api_urls + auth_urls + survey_urls

--- a/recoco/settings/common.py
+++ b/recoco/settings/common.py
@@ -350,6 +350,11 @@ REST_FRAMEWORK = {
         "rest_framework_xml.renderers.XMLRenderer",
     ],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_FILTER_BACKENDS": [
+        "django_filters.rest_framework.DjangoFilterBackend",
+    ],
+    # "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
+    "PAGE_SIZE": 50,
 }
 
 # https://django-rest-framework-simplejwt.readthedocs.io/en/latest/settings.html


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

Modification et extension de l'API REST actuelle, pour préparer https://github.com/betagouv/recommandations-collaboratives/pull/391
Le but étant d'utiliser les même serializers pour les payload du webhook et l'API.

- modification des serializers des projets pour extraire les données qui concerne le user dans un contexte de requête http
- ajout d'un endpoint API pour obtenir les sessions
- ajout d'un endpoint API pour obtenir les answers

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
