### PR TITLE
fix: do not drop materialized view anymore

### DIFF
--- a/recoco/apps/metrics/management/commands/update_materialized_views.py
+++ b/recoco/apps/metrics/management/commands/update_materialized_views.py
@@ -13,14 +13,6 @@ from typing import Any
 class Command(BaseCommand):
     help = "Update materialized view used for metrics"
 
-    def add_arguments(self, parser):
-        parser.add_argument(
-            "--drop-only",
-            default=False,
-            action="store_true",
-            help="Runs only drop operation",
-        )
-
     def _create_views_for_site(self, site: Site, **options: Any):
         self.stdout.write(
             f"Updating materialized views for site {site.name} (#{site.id})"
@@ -40,20 +32,10 @@ class Command(BaseCommand):
                     materialized_view.set_cursor(cursor)
 
                     self.stdout.write(
-                        f"Dropping materialized view '{materialized_view.db_view_name}'"
+                        f"  >> Refreshing materialized view '{materialized_view.db_schema_name}.{materialized_view.db_view_name}'"
                     )
-                    materialized_view.drop()
-
-                    if not options["drop_only"]:
-                        self.stdout.write(
-                            f"Creating materialized view '{materialized_view.db_view_name}'"
-                        )
-                        materialized_view.create()
-
-                        self.stdout.write(
-                            f"Refreshing materialized view '{materialized_view.db_view_name}'"
-                        )
-                        materialized_view.refresh()
+                    materialized_view.create()
+                    materialized_view.refresh()
 
     def handle(self, *args, **options):
         for site in Site.objects.order_by("id"):

--- a/recoco/apps/metrics/processor.py
+++ b/recoco/apps/metrics/processor.py
@@ -116,26 +116,21 @@ class MaterializedView:
 
         # Create the materialized view
         self.cursor.execute(
-            sql=f"CREATE MATERIALIZED VIEW {self.db_schema_name}.{self.db_view_name} AS ( {sql_query.sql} ) WITH NO DATA;",
+            sql=f"CREATE MATERIALIZED VIEW IF NOT EXISTS {self.db_schema_name}.{self.db_view_name} AS ( {sql_query.sql} ) WITH NO DATA;",
             params=sql_query.params,
         )
 
         # Create indexes if any
         for index in self.indexes:
             self.cursor.execute(
-                sql=f"CREATE INDEX ON {self.db_schema_name}.{self.db_view_name} ({index});"
+                sql=f"CREATE INDEX IF NOT EXISTS {index} ON {self.db_schema_name}.{self.db_view_name} ({index});"
             )
 
         # Create unique indexes if any
         for index in self.unique_indexes:
             self.cursor.execute(
-                sql=f"CREATE UNIQUE INDEX ON {self.db_schema_name}.{self.db_view_name} ({index});"
+                sql=f"CREATE UNIQUE INDEX IF NOT EXISTS {index} ON {self.db_schema_name}.{self.db_view_name} ({index});"
             )
-
-    def drop(self) -> None:
-        self.cursor.execute(
-            sql=f"DROP MATERIALIZED VIEW IF EXISTS {self.db_schema_name}.{self.db_view_name};"
-        )
 
     def refresh(self) -> None:
         self.cursor.execute(


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

Le fait de supprimer les vues matérialisées et les recréer entraine des problèmes au niveau de l'attribution des droits sur les schemas.
Désormais, on ne fait que du refresh et j'ai passé tous les requêtes de création (schema, vues, index) en `IF NOT EXISTS`.

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
