### PR TITLE
[siteDefault] fix - change UV terms by generic ones for site by default

### DIFF
--- a/recoco/templates/default_site/account/email/email_confirmation_signup_message.html
+++ b/recoco/templates/default_site/account/email/email_confirmation_signup_message.html
@@ -6,7 +6,7 @@
   <head>
     <meta name="viewport" content="width=device-width" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title>Confirmez votre adresse email sur UrbanVitaliz</title>
+    <title>Confirmez votre adresse email sur {{ request.site.name }}</title>
     <style>
       /* -------------------------------------
           GLOBAL RESETS
@@ -337,7 +337,7 @@
                             </strong>
                           </p>
                           <p>Bonne journée,</p>
-                          <p>L'équipe UrbanVitaliz</p>
+                          <p>L'équipe {{ request.site.name }}</p>
                         </div>
                       </td>
                     </tr>

--- a/recoco/templates/default_site/account/email/email_confirmation_subject.txt
+++ b/recoco/templates/default_site/account/email/email_confirmation_subject.txt
@@ -1,3 +1,3 @@
 {% autoescape off %}
-Confirmez votre adresse email sur UrbanVitaliz
+Confirmez votre adresse email sur {{ request.site.name }}
 {% endautoescape %}

--- a/recoco/templates/default_site/account/email/password_reset_key_message.html
+++ b/recoco/templates/default_site/account/email/password_reset_key_message.html
@@ -5,7 +5,7 @@
   <head>
     <meta name="viewport" content="width=device-width" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title>Modification de votre mot de passe sur UrbanVitaliz</title>
+    <title>Modification de votre mot de passe sur {{ request.site.name }}</title>
     <style>
       /* -------------------------------------
           GLOBAL RESETS
@@ -338,7 +338,7 @@
                             </strong>
                           </p>
                           <p>Bonne journée,</p>
-                          <p>L'équipe UrbanVitaliz</p>
+                          <p>L'équipe {{ request.site.name }}</p>
                         </div>
                       </td>
                     </tr>

--- a/recoco/templates/default_site/account/email/password_reset_key_subject.txt
+++ b/recoco/templates/default_site/account/email/password_reset_key_subject.txt
@@ -1,3 +1,3 @@
 {% autoescape off %}
-Modification de votre mot de passe sur UrbanVitaliz
+Modification de votre mot de passe sur {{ request.site.name }}
 {% endautoescape %}

--- a/recoco/templates/default_site/account/password_reset_from_key.html
+++ b/recoco/templates/default_site/account/password_reset_from_key.html
@@ -30,7 +30,7 @@
     {% if token_fail %}
       {% url 'account_reset_password' as passwd_reset_url %}
       <p>
-        {% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}
+        {% blocktrans %}The password reset link was invalid, possibly because it has already been used. Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}
       </p>
     {% else %}
       <form class="fr-form-group" method="POST" action="{{ action_url }}">

--- a/recoco/templates/default_site/magicauth/email.html
+++ b/recoco/templates/default_site/magicauth/email.html
@@ -3,7 +3,7 @@
   <head>
     <meta name="viewport" content="width=device-width" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-    <title>Connectez-vous à UrbanVitaliz ici</title>
+    <title>Connectez-vous à {{ request.site.name }} ici</title>
     <style>
       /* -------------------------------------
           GLOBAL RESETS
@@ -301,7 +301,7 @@
                     <tr>
                       <td>
                         <p>Bonjour,</p>
-                        <p>Pour accéder à UrbanVitaliz, vous avez juste à cliquer sur ce bouton :</p>
+                        <p>Pour accéder à {{ request.site.name }}, vous avez juste à cliquer sur ce bouton :</p>
                         <table border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
                           <tbody>
                             <tr>
@@ -330,7 +330,7 @@
                             </strong>
                           </p>
                           <p>Bonne journée,</p>
-                          <p>L'équipe UrbanVitaliz</p>
+                          <p>L'équipe {{ request.site.name }}</p>
                         </div>
                       </td>
                     </tr>

--- a/recoco/templates/default_site/magicauth/email.txt
+++ b/recoco/templates/default_site/magicauth/email.txt
@@ -1,9 +1,9 @@
 Bonjour,
 
-Pour accéder à UrbanVitaliz, vous avez juste à cliquer sur ce lien de connexion:  https://{{ site.domain }}{% url 'magicauth-wait' token.key %}?next={{ next_url|urlencode }}
+Pour accéder à {{ request.site.name }}, vous avez juste à cliquer sur ce lien de connexion:  https://{{ site.domain }}{% url 'magicauth-wait' token.key %}?next={{ next_url|urlencode }}
 
 Ce lien n'est valable que 3 jours. Il est à usage unique.
 
 Bonne journée,
 
-L'équipe UrbanVitaliz
+L'équipe {{ request.site.name }}


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Modification des fichiers emails et passwords pour les dossiers account et magicauth pour changer les références à UrbanVitaliz par une référence générique. Ceci permettant aux futures plateformes de bénéficier des fichiers par défauts pour les mails et les modifications de mots de passe.

Cette PR est liée à [celle-ci](https://github.com/betagouv/recoco-portails/pull/80) car elle permettra de bien envoyer des mails générique et non avec des occurances persistantes d'UV.

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [x] Je souhaite un déploiement en préproduction
Pour être sûr que cela fonctionne, faire des tests des emails.