### PR TITLE
:construction: [feat] harmonize the "list" API endpoints 

### DIFF
--- a/recoco/apps/projects/static/projects/js/action_pusher.js
+++ b/recoco/apps/projects/static/projects/js/action_pusher.js
@@ -1,3 +1,6 @@
+import api, { resourceListUrl } from '../utils/api';
+
+
 function action_pusher_app() {
 	return {
 		isBusy: true,
@@ -108,12 +111,10 @@ function action_pusher_app() {
 		},
 
 		async getResources() {
-			var tasksFromApi = [];
-
 			this.isBusy = true;
 
-			const response = await fetch('/api/resources/');
-			resourcesFromApi = await response.json(); //extract JSON from the http response
+			const json = await api.get(resourceListUrl());
+			const resourcesFromApi = json.data.results;
 
 			resourcesFromApi.forEach((t) => {
 				let entry = {

--- a/recoco/apps/projects/views/rest.py
+++ b/recoco/apps/projects/views/rest.py
@@ -15,6 +15,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404
 from notifications import models as notifications_models
 from rest_framework import permissions, status, viewsets
+from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -81,17 +82,14 @@ class ProjectDetail(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-class ProjectList(APIView):
+class ProjectList(ListAPIView):
     """List all user project status"""
 
     permission_classes = [permissions.IsAuthenticated]
+    serializer_class = ProjectForListSerializer
 
-    def get(self, request, format=None):
-        projects = fetch_the_site_projects(request.site, request.user)
-        context = {"request": request}
-
-        serializer = ProjectForListSerializer(projects, context=context, many=True)
-        return Response(serializer.data)
+    def get_queryset(self):
+        return fetch_the_site_projects(self.request.site, self.request.user)
 
 
 def fetch_the_site_projects(site, user):
@@ -236,17 +234,16 @@ class UserProjectStatusDetail(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-class UserProjectStatusList(APIView):
+class UserProjectStatusList(ListAPIView):
     """List all user project status"""
 
     permission_classes = [permissions.IsAuthenticated]
+    serializer_class = UserProjectStatusForListSerializer
 
-    def get(self, request, format=None):
-        ups = fetch_the_site_project_statuses_for_user(request.site, request.user)
-        context = {"request": request}
-
-        serializer = UserProjectStatusForListSerializer(ups, context=context, many=True)
-        return Response(serializer.data)
+    def get_queryset(self):
+        return fetch_the_site_project_statuses_for_user(
+            self.request.site, self.request.user
+        )
 
 
 def fetch_the_site_project_statuses_for_user(site, user):

--- a/recoco/apps/resources/tests/test_rest.py
+++ b/recoco/apps/resources/tests/test_rest.py
@@ -33,8 +33,12 @@ def test_anonymous_can_see_resources_list_api(request):
     url = reverse("resources-list")
     client = APIClient()
     response = client.get(url)
+
     assert response.status_code == 200
-    assert response.data[0]["title"] == resource.title
+    assert response.data["count"] == 1
+
+    first = response.data["results"][0]
+    assert first["title"] == resource.title
 
 
 @pytest.mark.django_db
@@ -46,11 +50,11 @@ def test_anonymous_cannot_see_unpublished_resource_in_list_api(request):
         title=" to review resource",
     ).make()
 
-    url = reverse("resources-list")
     client = APIClient()
-    response = client.get(url)
+    response = client.get(reverse("resources-list"))
+
     assert response.status_code == 200
-    assert len(response.data) == 0
+    assert len(response.data["results"]) == 0
 
 
 @pytest.mark.django_db
@@ -68,13 +72,16 @@ def test_staff_can_see_unpublished_resource_in_list_api(request):
     gstaff = auth_models.Group.objects.get(name="example_com_staff")
     staff.groups.add(gstaff)
 
-    url = reverse("resources-list")
     client = APIClient()
     client.force_authenticate(user=staff)
-    response = client.get(url)
+
+    response = client.get(reverse("resources-list"))
+
     assert response.status_code == 200
-    assert len(response.data) == 1
-    assert response.data[0]["title"] == resource.title
+    assert response.data["count"] == 1
+
+    first = response.data["results"][0]
+    assert first["title"] == resource.title
 
 
 @pytest.mark.django_db

--- a/recoco/apps/tasks/tests/test_rest.py
+++ b/recoco/apps/tasks/tests/test_rest.py
@@ -44,11 +44,12 @@ def test_project_collaborator_can_see_project_tasks_for_site(request, project):
 
     client = APIClient()
     client.force_authenticate(user=user)
-    url = reverse("project-tasks-list", args=[project.id])
-    response = client.get(url)
+
+    response = client.get(reverse("project-tasks-list", args=[project.id]))
 
     assert response.status_code == 200
-    assert set(e["id"] for e in response.data) == set(t.id for t in tasks)
+    assert response.data["count"] == 2
+    assert set(e["id"] for e in response.data["results"]) == set(t.id for t in tasks)
 
 
 @pytest.mark.django_db
@@ -61,13 +62,14 @@ def test_task_includes_resource_content_bug_fix(request, project):
 
     client = APIClient()
     client.force_authenticate(user=user)
-    url = reverse("project-tasks-list", args=[project.id])
-    response = client.get(url)
+
+    response = client.get(reverse("project-tasks-list", args=[project.id]))
 
     assert response.status_code == 200
+    assert response.data["count"] == 1
 
-    task = response.data[0]
-    assert task["resource"] is not None
+    first = response.data["results"][0]
+    assert first["resource"] is not None
 
 
 @pytest.mark.django_db
@@ -82,11 +84,12 @@ def test_project_observer_can_see_project_tasks_for_site(request, project):
 
     client = APIClient()
     client.force_authenticate(user=user)
-    url = reverse("project-tasks-list", args=[project.id])
-    response = client.get(url)
+
+    response = client.get(reverse("project-tasks-list", args=[project.id]))
 
     assert response.status_code == 200
-    assert set(e["id"] for e in response.data) == set(t.id for t in tasks)
+    assert response.data["count"] == 2
+    assert set(e["id"] for e in response.data["results"]) == set(t.id for t in tasks)
 
 
 @pytest.mark.django_db
@@ -107,7 +110,8 @@ def test_regional_actor_can_see_project_tasks_for_site(request, project):
         response = client.get(url)
 
     assert response.status_code == 200
-    assert set(e["id"] for e in response.data) == set(t.id for t in tasks)
+    assert response.data["count"] == 2
+    assert set(e["id"] for e in response.data["results"]) == set(t.id for t in tasks)
 
 
 @pytest.mark.django_db
@@ -122,11 +126,12 @@ def test_project_advisor_can_see_project_tasks_for_site(request, project):
 
     client = APIClient()
     client.force_authenticate(user=user)
-    url = reverse("project-tasks-list", args=[project.id])
-    response = client.get(url)
+
+    response = client.get(reverse("project-tasks-list", args=[project.id]))
 
     assert response.status_code == 200
-    assert set(e["id"] for e in response.data) == set(t.id for t in tasks)
+    assert response.data["count"] == 2
+    assert set(e["id"] for e in response.data["results"]) == set(t.id for t in tasks)
 
 
 @pytest.mark.django_db
@@ -137,8 +142,8 @@ def test_user_cannot_see_project_tasks_when_not_in_relation(request, project):
 
     client = APIClient()
     client.force_authenticate(user=user)
-    url = reverse("project-tasks-list", args=[project.id])
-    response = client.get(url)
+
+    response = client.get(reverse("project-tasks-list", args=[project.id]))
 
     assert response.status_code == 403
 
@@ -512,11 +517,13 @@ def test_project_task_followup_list_closed_for_dissociate_task_and_project(
 
     client = APIClient()
     client.force_authenticate(user=user)
-    url = reverse("project-tasks-followups-list", args=[project1.id, task2.id])
-    response = client.get(url)
+
+    response = client.get(
+        reverse("project-tasks-followups-list", args=[project1.id, task2.id])
+    )
 
     assert response.status_code == 200
-    assert len(response.data) == 0
+    assert len(response.data["results"]) == 0
 
 
 @pytest.mark.django_db
@@ -530,13 +537,15 @@ def test_project_task_followup_list_returns_followups_to_collaborator(request, p
 
     client = APIClient()
     client.force_authenticate(user=user)
-    url = reverse("project-tasks-followups-list", args=[project.id, task.id])
-    response = client.get(url)
+
+    response = client.get(
+        reverse("project-tasks-followups-list", args=[project.id, task.id])
+    )
 
     assert response.status_code == 200
-    assert len(response.data) == 1
+    assert response.data["count"] == 1
 
-    first = response.data[0]
+    first = response.data["results"][0]
     expected_fields = [
         "comment",
         "id",
@@ -701,13 +710,15 @@ def test_project_task_notifications_list_returns_notifications_of_advisor(
 
     client = APIClient()
     client.force_authenticate(user=user)
-    url = reverse("project-tasks-notifications-list", args=[project.id, task.id])
-    response = client.get(url)
+
+    response = client.get(
+        reverse("project-tasks-notifications-list", args=[project.id, task.id])
+    )
 
     assert response.status_code == 200
-    assert len(response.data) == 1
+    assert response.data["count"] == 1
 
-    first = response.data[0]
+    first = response.data["results"][0]
     expected_fields = [
         "action_object",
         "actor",

--- a/recoco/frontend/src/js/components/CitySelect.js
+++ b/recoco/frontend/src/js/components/CitySelect.js
@@ -1,4 +1,6 @@
 import Alpine from 'alpinejs';
+import { communeListUrl } from '../utils/api';
+
 import {
   addClassIfNotExists,
   removeAndAddClassConditionaly,
@@ -78,11 +80,11 @@ function CitySearch(required = false, requestMethod = 'GET', dsfr = false) {
       if (this.postal == '') return;
 
       this.isLoading = true;
-      fetch(`/api/communes/?postal=${this.postal}`)
+      fetch(communeListUrl(this.postal))
         .then((res) => res.json())
         .then((data) => {
           this.isLoading = false;
-          this.cities = data;
+          this.cities = data.results;
           if (dsfr && this.cities.length == 1) {
             removeAndAddClassConditionaly(
               true,

--- a/recoco/frontend/src/js/components/KanbanProjects.js
+++ b/recoco/frontend/src/js/components/KanbanProjects.js
@@ -2,11 +2,7 @@ import Alpine from 'alpinejs';
 import { generateUUID } from '../utils/uuid';
 import Fuse from 'fuse.js';
 
-import api, {
-  projectsProjectSitesUrl,
-  projectsUrl,
-  regionsUrl,
-} from '../utils/api';
+import api, { regionListUrl, projectListUrl, projectUrl } from '../utils/api';
 
 Alpine.data('KanbanProjects', boardProjectsApp);
 
@@ -40,13 +36,13 @@ function boardProjectsApp(currentSiteId) {
     fuse: null,
     searchText: '',
     async getData(postProcess = true) {
-      const projects = await api.get(projectsUrl());
+      const projects = await api.get(projectListUrl());
       await this.$store.projects.mapperProjetsProjectSites(
-        projects.data,
+        projects.data.results,
         this.currentSiteId
       );
 
-      const projectList = projects.data.map((d) =>
+      const projectList = projects.data.results.map((d) =>
         Object.assign(d, {
           uuid: generateUUID(),
         })

--- a/recoco/frontend/src/js/components/Map.js
+++ b/recoco/frontend/src/js/components/Map.js
@@ -5,7 +5,7 @@ import 'leaflet-providers';
 
 import { statusToText, statusToColorClass } from '../utils/statusToText';
 
-import api from '../utils/api';
+import api, { projectListUrl } from '../utils/api';
 Alpine.data('Map', Map);
 
 function Map() {
@@ -17,9 +17,8 @@ function Map() {
     },
 
     async getData() {
-      const json = await api.get('/api/projects/');
-
-      this.data = json.data;
+      const json = await api.get(projectListUrl());
+      this.data = json.data.results;
     },
 
     async init() {

--- a/recoco/frontend/src/js/components/OrganizationSearch.js
+++ b/recoco/frontend/src/js/components/OrganizationSearch.js
@@ -57,10 +57,10 @@ function OrganizationSearch(
 
       try {
         if (e.target.value.length > 2) {
-          const results = await api.get(searchOrganizationsUrl(e.target.value));
+          const json = await api.get(searchOrganizationsUrl(e.target.value));
 
-          if (results && results.data) {
-            return (this.results = results.data);
+          if (json.data.count > 0) {
+            return (this.results = json.data.results);
           }
         } else {
           return (this.results = []);

--- a/recoco/frontend/src/js/components/Projects.js
+++ b/recoco/frontend/src/js/components/Projects.js
@@ -1,5 +1,5 @@
 import Alpine from 'alpinejs';
-import api from '../utils/api';
+import api, { userProjectStatusUrl } from '../utils/api';
 import { formatDate } from '../utils/date';
 import { gravatar_url } from '../utils/gravatar';
 import { makeProjectURL } from '../utils/createProjectUrl';
@@ -120,7 +120,7 @@ function AdvisorDashboard() {
       const data = this.data.find((d) => d.id === JSON.parse(id));
 
       try {
-        await api.patch(`/api/userprojectstatus/${data.id}/`, {
+        await api.patch(userProjectStatusUrl(data.id), {
           status: status,
         });
       } catch (err) {

--- a/recoco/frontend/src/js/components/TopicSearch.js
+++ b/recoco/frontend/src/js/components/TopicSearch.js
@@ -11,11 +11,11 @@ function TopicSearch(currentTopic, restrict_to = null) {
       this.topic = currentTopic;
       this.restrict_to = restrict_to;
       if (currentTopic) {
-        const results = await api.get(
+        const json = await api.get(
           searchTopicsUrl(currentTopic, this.restrict_to)
         );
-        if (results && results.data) {
-          return (this.results = results.data);
+        if (json.data.count > 0) {
+          return (this.results = json.data.results);
         }
       }
     },
@@ -24,12 +24,12 @@ function TopicSearch(currentTopic, restrict_to = null) {
 
       try {
         if (e.target.value.length > 2) {
-          const results = await api.get(
+          const json = await api.get(
             searchTopicsUrl(e.target.value, this.restrict_to)
           );
 
-          if (results && results.data) {
-            return (this.results = results.data);
+          if (json.data.count > 0) {
+            return (this.results = json.data.results);
           }
         } else {
           return (this.results = []);

--- a/recoco/frontend/src/js/components/Tutorial.js
+++ b/recoco/frontend/src/js/components/Tutorial.js
@@ -58,7 +58,7 @@ function Tutorial(challengeCode, autoStart = false) {
     async getChallengeDefinition(code) {
       try {
         const json = await api.get(challengeDefinitionUrl(code));
-        return json.data;
+        return json.data.results;
       } catch (err) {
         console.warn(err);
       }

--- a/recoco/frontend/src/js/store/previewModal.js
+++ b/recoco/frontend/src/js/store/previewModal.js
@@ -102,13 +102,13 @@ document.addEventListener('alpine:init', () => {
       const { data } = await api.get(followupsUrl(this.projectId, this.taskId));
       Alpine.store('tasksData').markAllAsRead(this.taskId);
       await Alpine.store('tasksView').updateView();
-      this.followups = data;
+      this.followups = data.resuts;
     },
     async loadNotifications() {
       const { data } = await api.get(
         taskNotificationsUrl(this.projectId, this.taskId)
       );
-      this.notifications = data;
+      this.notifications = data.results;
     },
     async setTaskIsVisited() {
       if (!Alpine.store('djangoData').isAdvisor) {

--- a/recoco/frontend/src/js/store/projects.js
+++ b/recoco/frontend/src/js/store/projects.js
@@ -8,12 +8,12 @@ Alpine.store('projects', {
   async getUserProjetsStatus() {
     const json = await api.get(userProjectStatusUrl());
 
-    return (this.userProjetsStatus = json.data);
+    return (this.userProjetsStatus = json.data.results);
   },
   async getSitesConfig() {
     const json = await api.get(sitesConfigUrl());
 
-    return (this.sitesConfig = json.data);
+    return (this.sitesConfig = json.data.results);
   },
   async mapperProjetsProjectSites(projects, currentSiteId) {
     if (this.sitesConfig.length === 0) {

--- a/recoco/frontend/src/js/store/tasksData.js
+++ b/recoco/frontend/src/js/store/tasksData.js
@@ -48,7 +48,7 @@ document.addEventListener('alpine:init', () => {
     async loadTasks() {
       const json = await api.get(tasksUrl(this.projectId));
 
-      const data = json.data.map((d) =>
+      const data = json.data.results.map((d) =>
         Object.assign(d, {
           // TODO: Virer les UUID
           uuid: generateUUID(),

--- a/recoco/frontend/src/js/utils/api.js
+++ b/recoco/frontend/src/js/utils/api.js
@@ -37,17 +37,21 @@ instance.interceptors.response.use(
 
 export default instance;
 
-// Projects :
-export function projectsUrl() {
-  return '/api/projects/';
+// Projects
+export function projectListUrl() {
+  return `/api/projects/?limit=1000`;
 }
 
-export function projectsProjectSitesUrl() {
-  return '/api/projects/projectsites/';
+export function projectUrl(projectId) {
+  return `/api/projects/${projectId}/`;
 }
 
-export function userProjectStatusUrl() {
-  return '/api/userprojectstatus/';
+export function userProjectStatusListUrl() {
+  return `/api/userprojectstatus/?limit=1000`;
+}
+
+export function userProjectStatusUrl(userProjectStatusId) {
+  return `/api/userprojectstatus/${userProjectStatusId}/`;
 }
 
 // Sites :
@@ -57,21 +61,22 @@ export function sitesConfigUrl() {
 
 // Organization
 export function searchOrganizationsUrl(search) {
-  return `/api/organizations/?search=${search}`;
+  return `/api/organizations/?search=${search}&limit=1000`;
 }
 
 // Topic
 export function searchTopicsUrl(search, restrict_to) {
-  return `/api/topics/?search=${search}&restrict_to=${restrict_to}`;
+  return `/api/topics/?search=${search}&restrict_to=${restrict_to}&limit=1000`;
 }
 
-// Tasks :
+// Tasks
 export function taskUrl(projectId, taskId) {
   return `/api/projects/${projectId}/tasks/${taskId}/`;
 }
 
+// FIXME: dead code ?
 export function tasksUrl(projectId) {
-  return `/api/projects/${projectId}/tasks/`;
+  return `/api/projects/${projectId}/tasks/?limit=1000`;
 }
 
 export function moveTaskUrl(projectId, taskId) {
@@ -79,7 +84,7 @@ export function moveTaskUrl(projectId, taskId) {
 }
 
 export function taskNotificationsUrl(projectId, taskId) {
-  return `/api/projects/${projectId}/tasks/${taskId}/notifications/`;
+  return `/api/projects/${projectId}/tasks/${taskId}/notifications/?limit=1000`;
 }
 
 export function markTaskNotificationsAsReadUrl(projectId, taskId) {
@@ -99,7 +104,7 @@ export function markAllNotificationsAsReadUrl() {
 }
 
 export function followupsUrl(projectId, taskId) {
-  return `/api/projects/${projectId}/tasks/${taskId}/followups/`;
+  return `/api/projects/${projectId}/tasks/${taskId}/followups/?limit=1000`;
 }
 
 export function followupUrl(projectId, taskId, followupId) {
@@ -110,9 +115,18 @@ export function resourcePreviewUrl(resourceId) {
   return `/ressource/${resourceId}/embed`;
 }
 
-// Regions :
-export function regionsUrl() {
-  return `/api/regions/`;
+export function resourceListUrl() {
+  return `/api/ressources/?limit=1000`;
+}
+
+// Regions
+export function regionListUrl() {
+  return `/api/regions/?limit=1000`;
+}
+
+// Communes
+export function communeListUrl(postal) {
+  return `/api/communes/?postal=${postal}&limit=1000`;
 }
 
 // Challenges

--- a/recoco/settings/common.py
+++ b/recoco/settings/common.py
@@ -352,8 +352,8 @@ REST_FRAMEWORK = {
     "DEFAULT_FILTER_BACKENDS": [
         "django_filters.rest_framework.DjangoFilterBackend",
     ],
-    # "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
-    "PAGE_SIZE": 50,
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
+    "PAGE_SIZE": 100,
 }
 
 # https://django-rest-framework-simplejwt.readthedocs.io/en/latest/settings.html

--- a/recoco/tests.py
+++ b/recoco/tests.py
@@ -177,11 +177,14 @@ def test_rest_api_responds_to_xml_content_type(client, request):
     client.force_authenticate(user=user)
 
     url = reverse("resources-list")
-    response = client.get(f"{url}?format=xml")
 
+    response = client.get(f"{url}?format=xml")
     assert response.status_code == 200
     assert "application/xml" in response.headers["content-type"]
-    assert len(response.data) == 1
+
+    response = client.get(f"{url}?format=json")
+    assert response.status_code == 200
+    assert "application/json" in response.headers["content-type"]
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

- tous les endpoitns d'API retournent un objet et non pas une liste
- la pagiantion est active par défaut (activé dans les settings classiques DRF)
- avoir à dispo le paramètre "count"
- simplification des vues d'API à l'aide de `ListAPIView`
- regrouper tous les appels d'API dans `api.js`

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
