### PR TITLE
[hotfix] dragndrop firefox

### DIFF
--- a/recoco/apps/projects/templates/projects/project/list-kanban.html
+++ b/recoco/apps/projects/templates/projects/project/list-kanban.html
@@ -47,6 +47,8 @@
                                                      @drop="onDrop(event, board.code, null)"
                                                      @dragenter="onDragEnter(event)"
                                                      @dragleave="onDragLeave(event)"
+                                                     @dragstart="onDragStart(event, t.uuid)"
+                                                     @dragend="onDragEnd(event)"
                                                      data-test-id="drag-target">
                                                     <div class="drag-placeholder"></div>
                                                     <span x-text=board.status></span>
@@ -59,13 +61,13 @@
                                                      @dragover="onDragOver(event)"
                                                      @drop="onDrop(event, board.code, t.uuid)"
                                                      @dragenter="onDragEnter(event)"
-                                                     @dragleave="onDragLeave(event)">
+                                                     @dragleave="onDragLeave(event)"
+                                                     @dragstart="onDragStart(event, t.uuid)"
+                                                     @dragend="onDragEnd(event)">
                                                     <a :href="makeProjectURL(t.id)">
                                                         <div class="kanban-card rounded p-2 w-100 position-relative"
                                                              :class="{'kanban-card--border__is-switchtender': t.is_switchtender, 'kanban-card--border__is-observer': t.is_observer}"
                                                              draggable="true"
-                                                             @dragstart="onDragStart(event, t.uuid)"
-                                                             @dragend="onDragEnd(event)"
                                                              :data-test-id="`item-draggable-${taskIndex}`">
                                                             <template x-if="t.inactive_since !== null">
                                                                 <div class="kanban-card--state-container">


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Sur certaines version de Firefox, il était impossible de drag and drop les projets du kanban. 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
