### PR TITLE
fix: make celery work

### DIFF
--- a/makefile
+++ b/makefile
@@ -57,6 +57,6 @@ runserver:
 	@python manage.py runserver 0.0.0.0:8000
 
 runworker:
-	@celery -A recoco.worker worker -l info --concurrency=1
+	@celery -A recoco worker -l info --concurrency=1
 
 # eof

--- a/recoco/apps/__init__.py
+++ b/recoco/apps/__init__.py
@@ -1,0 +1,3 @@
+from ..celery import app as celery_app
+
+__all__ = ["celery_app"]

--- a/recoco/apps/home/tasks.py
+++ b/recoco/apps/home/tasks.py
@@ -1,0 +1,7 @@
+from celery import shared_task
+
+
+@shared_task
+def empty_task():
+    # TODO: for debug purpose, remove this later
+    pass

--- a/recoco/settings/common.py
+++ b/recoco/settings/common.py
@@ -397,6 +397,10 @@ MATERIALIZED_VIEWS_SQL_DIR = BASE_DIR / "apps/metrics/sql_queries"
 BAKER_CUSTOM_CLASS = "recoco.tests.CustomBaker"
 
 # CELERY
+CELERY_TIMEZONE = "Europe/Paris"
+CELERY_TASK_TRACK_STARTED = True
+CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", default="redis://localhost:6379/0")
+CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
 CELERY_RESULT_BACKEND = "django-db"
 
 # Metabase


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

Ajout de changements pour faire fonctionner Celery.
J'ai ajouté une première tâche, vide, pour pouvoir tester le process entier.

J'arrive à exécuter la tâche de test uniquement si les imports de celery sont présents.
```python
from recoco.apps.home.tasks import empty_task
empty_task.delay()
```

J'ai testé le setup en deux étapes:
- Je build l'archive
```python
from distutils.core import run_setup
run_setup("setup.py", script_args=["sdist"])
```
- Je l'installe dans un venv
```bash
python -m venv .venv
source .venv/bin/activate
pip install dist/recoco-2.32.0.tar.gz 
```

J'ai des erreurs à l'installation si les import sont faits dans le `recoco/__init__.py` (l'appel de celery semble arriver trop tôt).
Je n'ai plus d'erreur à l'installation si les import de celery sont dans le fichier `recoco/apps/__init__.py` 


## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
