### PR TITLE
[feat] add documentation to profil dropdown menu and move carnet d'ad…

### DIFF
--- a/frontend_tests/cypress/e2e/header/canAccessAdressBook.cy.js
+++ b/frontend_tests/cypress/e2e/header/canAccessAdressBook.cy.js
@@ -1,0 +1,28 @@
+describe('I can access to my adress book', () => {
+  beforeEach(() => {
+    cy.login('staff');
+  });
+
+  it('', () => {
+    cy.visit(`/`);
+    cy.get("[data-test-id='open-dropdown-profil-option-button']").click({
+      force: true,
+    });
+    cy.get("[data-test-id='button-adress-book']").click({ force: true });
+    cy.url().should('include', '/addressbook/organizations');
+  });
+});
+
+describe("I can't see adress book because I don't have one", () => {
+  beforeEach(() => {
+    cy.login('jean');
+  });
+
+  it('', () => {
+    cy.visit(`/`);
+    cy.get('[data-test-id="open-dropdown-profil-option-button"]').click({
+      force: true,
+    });
+    cy.get('[data-test-id="button-adress-book"]').should('not.exist');
+  });
+});

--- a/frontend_tests/cypress/e2e/header/canAccessDocumentation.cy.js
+++ b/frontend_tests/cypress/e2e/header/canAccessDocumentation.cy.js
@@ -1,0 +1,45 @@
+describe('I can access documentation', () => {
+  it('displays as staff member', () => {
+    cy.login('staff');
+    cy.hideCookieBannerAndDjango();
+    cy.visit(`/`);
+    cy.get("[data-test-id='open-dropdown-profil-option-button']").click({
+      force: true,
+    });
+    cy.get('[data-test-id="documentation-button-staff"]').click({
+      force: true,
+    });
+    cy.url().should('include', 'pour-les-administrateurs-dun-portail');
+    // cy.visit(`/`);
+    // cy.logout();
+  });
+
+  xit('displays as advisor', () => {
+    cy.login('jean');
+    cy.hideCookieBannerAndDjango();
+    cy.visit(`/`);
+    cy.get("[data-test-id='open-dropdown-profil-option-button']").click({
+      force: true,
+    });
+    cy.get('[data-test-id="documentation-button-advisor"]').click({
+      force: true,
+    });
+    cy.url().should(
+      'include',
+      'pour-les-acteurs-publics-qui-conseillent-les-collectivites'
+    );
+    // cy.visit(`/`);
+    // cy.logout();
+  });
+
+  it('cannnot displays it', () => {
+    cy.login('bob');
+    cy.hideCookieBannerAndDjango();
+    cy.visit(`/`);
+    cy.get('[data-test-id="open-dropdown-profil-option-button"]').click({
+      force: true,
+    });
+    cy.contains('Documentation').should('not.exist');
+    // cy.logout();
+  });
+});

--- a/frontend_tests/cypress/e2e/header/canAccessDocumentation.cy.js
+++ b/frontend_tests/cypress/e2e/header/canAccessDocumentation.cy.js
@@ -14,7 +14,7 @@ describe('I can access documentation', () => {
     // cy.logout();
   });
 
-  xit('displays as advisor', () => {
+  it('displays as advisor', () => {
     cy.login('jean');
     cy.hideCookieBannerAndDjango();
     cy.visit(`/`);

--- a/recoco/settings/common.py
+++ b/recoco/settings/common.py
@@ -150,7 +150,6 @@ TEMPLATES = [
             ],
             "libraries": {
                 "common_tags": "recoco.templatetags.common_extra",
-                "dsrc_tags": "recoco.apps.dsrc.templatetags.dsrc_tags",
             },
         },
     },

--- a/recoco/templates/default_site/header/menu-top-secondary.html
+++ b/recoco/templates/default_site/header/menu-top-secondary.html
@@ -213,15 +213,6 @@
                 {% endif %}
             </div>
         </li>
-        <!-- Address Book -->
-        {% if "use_addressbook" in user_site_perms %}
-            <li class="{% if 'addressbook' in url_name %}activated{% endif %}">
-                <a href="{% url 'addressbook-organization-list' %}"
-                   class="nav-link link-dark {% if url_name == 'addressbook-organization-list' %}active{% endif %}">
-                    <span class="ms-1 me-2 align-middle">Carnet d'adresses</span>
-                </a>
-            </li>
-        {% endif %}
         <!-- Notifications -->
         {% if user.is_authenticated %}
             <li class="dropdown"

--- a/recoco/templates/default_site/header/menu-top-user-tools.html
+++ b/recoco/templates/default_site/header/menu-top-user-tools.html
@@ -10,7 +10,8 @@
          class="dropdown">
       <a x-on:click="open = !open"
          href="#"
-         class="d-flex align-items-center link-dark text-decoration-none">
+         class="d-flex align-items-center link-dark text-decoration-none"
+         data-test-id="open-dropdown-profil-option-button">
         <img src="{% gravatar_url user.email 16 %}"
              alt="{{ user.get_full_name }}"
              class="me-2 rounded-circle"
@@ -61,7 +62,11 @@
         <!-- Address Book -->
         {% if "use_addressbook" in user_site_perms %}
           <li class="{% if 'addressbook' in url_name %}activated{% endif %}">
-            <a href="{% url 'addressbook-organization-list' %}" class="small dropdown-item">Carnet d'adresses</a>
+            <a href="{% url 'addressbook-organization-list' %}"
+               class="small dropdown-item"
+               data-test-id="button-adress-book">
+                Carnet d'adresses
+            </a>
           </li>
           <li>
             <hr class="dropdown-divider">
@@ -69,14 +74,18 @@
         {% endif %}
         {% if user.is_staff %}
           <li>
-            <a class="small dropdown-item" href="https://app.gitbook.com/o/nS3kWPp33JdseoHho2Gv/s/ERzX4YZ3RcvyxL3VUccS/pour-les-administrateurs-dun-portail">Documentation</a>
+            <a class="small dropdown-item"
+            href="https://app.gitbook.com/o/nS3kWPp33JdseoHho2Gv/s/ERzX4YZ3RcvyxL3VUccS/pour-les-administrateurs-dun-portail"
+            data-test-id="documentation-button-staff">Documentation</a>
           </li>
           <li>
             <hr class="dropdown-divider">
           </li>
         {% elif user.is_advisor %}
           <li>
-            <a class="small dropdown-item" href="https://reco-co.gitbook.io/reco-co/pour-les-acteurs-publics-qui-conseillent-les-collectivites">Documentation</a>
+            <a class="small dropdown-item"
+            href="https://reco-co.gitbook.io/reco-co/pour-les-acteurs-publics-qui-conseillent-les-collectivites"
+            data-test-id="documentation-button-advisor">Documentation</a>
           </li>
           <li>
             <hr class="dropdown-divider">

--- a/recoco/templates/default_site/header/menu-top-user-tools.html
+++ b/recoco/templates/default_site/header/menu-top-user-tools.html
@@ -1,6 +1,8 @@
 {% load gravatar %}
 {% load static %}
 {% load guardian_tags %}
+{% load projects_extra %}
+{% is_staff_for_current_site request.user as is_staff %}
 <!-- User -->
 <div id="user-info" class="pe-2 ps-2 ms-2 me-2">
   {% if user.is_authenticated %}
@@ -47,11 +49,11 @@
           <li>
             <a class="dropdown-item small " href="{% url 'crm-site-dashboard' %}">CRM</a>
           </li>
-        {% endif %}
-        {% if user.is_staff %}
           <li>
             <hr class="dropdown-divider">
           </li>
+        {% endif %}
+        {% if user.is_staff %}
           <li>
             <a class="small dropdown-item" href="{% url 'admin:index' %}">Administration Reco-co</a>
           </li>
@@ -72,7 +74,7 @@
             <hr class="dropdown-divider">
           </li>
         {% endif %}
-        {% if user.is_staff %}
+        {% if is_staff %}
           <li>
             <a class="small dropdown-item"
             href="https://app.gitbook.com/o/nS3kWPp33JdseoHho2Gv/s/ERzX4YZ3RcvyxL3VUccS/pour-les-administrateurs-dun-portail"
@@ -81,25 +83,11 @@
           <li>
             <hr class="dropdown-divider">
           </li>
-        {% elif user.is_advisor %}
+        {% elif is_switchtender or is_administrating_project %}
           <li>
             <a class="small dropdown-item"
             href="https://reco-co.gitbook.io/reco-co/pour-les-acteurs-publics-qui-conseillent-les-collectivites"
             data-test-id="documentation-button-advisor">Documentation</a>
-          </li>
-          <li>
-            <hr class="dropdown-divider">
-          </li>
-        {% elif crm_user_is_advisor %}
-          <li>
-            <a class="small dropdown-item" href="https://reco-co.gitbook.io/reco-co/pour-les-acteurs-publics-qui-conseillent-les-collectivites">Yes I am</a>
-          </li>
-          <li>
-            <hr class="dropdown-divider">
-          </li>
-        {% elif position.is_advisor %}
-          <li>
-            <a class="small dropdown-item" href="https://reco-co.gitbook.io/reco-co/pour-les-acteurs-publics-qui-conseillent-les-collectivites">Yes I am</a>
           </li>
           <li>
             <hr class="dropdown-divider">

--- a/recoco/templates/default_site/header/menu-top-user-tools.html
+++ b/recoco/templates/default_site/header/menu-top-user-tools.html
@@ -52,7 +52,45 @@
             <hr class="dropdown-divider">
           </li>
           <li>
-            <a class="small  dropdown-item" href="{% url 'admin:index' %}">Administration Reco-co</a>
+            <a class="small dropdown-item" href="{% url 'admin:index' %}">Administration Reco-co</a>
+          </li>
+          <li>
+            <hr class="dropdown-divider">
+          </li>
+        {% endif %}
+        <!-- Address Book -->
+        {% if "use_addressbook" in user_site_perms %}
+          <li class="{% if 'addressbook' in url_name %}activated{% endif %}">
+            <a href="{% url 'addressbook-organization-list' %}" class="small dropdown-item">Carnet d'adresses</a>
+          </li>
+          <li>
+            <hr class="dropdown-divider">
+          </li>
+        {% endif %}
+        {% if user.is_staff %}
+          <li>
+            <a class="small dropdown-item" href="https://app.gitbook.com/o/nS3kWPp33JdseoHho2Gv/s/ERzX4YZ3RcvyxL3VUccS/pour-les-administrateurs-dun-portail">Documentation</a>
+          </li>
+          <li>
+            <hr class="dropdown-divider">
+          </li>
+        {% elif user.is_advisor %}
+          <li>
+            <a class="small dropdown-item" href="https://reco-co.gitbook.io/reco-co/pour-les-acteurs-publics-qui-conseillent-les-collectivites">Documentation</a>
+          </li>
+          <li>
+            <hr class="dropdown-divider">
+          </li>
+        {% elif crm_user_is_advisor %}
+          <li>
+            <a class="small dropdown-item" href="https://reco-co.gitbook.io/reco-co/pour-les-acteurs-publics-qui-conseillent-les-collectivites">Yes I am</a>
+          </li>
+          <li>
+            <hr class="dropdown-divider">
+          </li>
+        {% elif position.is_advisor %}
+          <li>
+            <a class="small dropdown-item" href="https://reco-co.gitbook.io/reco-co/pour-les-acteurs-publics-qui-conseillent-les-collectivites">Yes I am</a>
           </li>
           <li>
             <hr class="dropdown-divider">


### PR DESCRIPTION
…resse to it

Il s'agit de :
- [ ] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Déplacement du bouton carnet d'adresse sur le menu principal vers le menu déroulant au clique sur le compte d'un utilisateur sur le menu principal. Ajout d'un bouton "Documentation" dans ce même menu déroulant ne s'affichant que pour les membres du staff d'un portail (avec un lien vers une documentation associée), et pour les utilisateurs.rices en charge de conseiller au moins un projet (avec un lien vers une autre documentation assoicée). De nouveaux tests end-to-end ont été créés et utilisés pour l'occasion.

[Lien ticket github project](https://github.com/betagouv/recommandations-collaboratives/issues/495)

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [x] Je souhaite un déploiement en préproduction
Peut-être qu'une mise en pré-prod pourrait éviter d'éventuels bugs non prévus.