### PR TITLE
[fix] change account dropdown menu documentation links 

### DIFF
--- a/recoco/templates/default_site/header/menu-top-user-tools.html
+++ b/recoco/templates/default_site/header/menu-top-user-tools.html
@@ -77,8 +77,8 @@
         {% if is_staff %}
           <li>
             <a class="small dropdown-item"
-            href="https://app.gitbook.com/o/nS3kWPp33JdseoHho2Gv/s/ERzX4YZ3RcvyxL3VUccS/pour-les-administrateurs-dun-portail"
-            data-test-id="documentation-button-staff">Documentation</a>
+            href="https://reco-co.gitbook.io/reco-co/pour-les-administrateurs-dun-portail"
+            data-test-id="documentation-button-staff" target="_blank">Documentation</a>
           </li>
           <li>
             <hr class="dropdown-divider">
@@ -87,7 +87,7 @@
           <li>
             <a class="small dropdown-item"
             href="https://reco-co.gitbook.io/reco-co/pour-les-acteurs-publics-qui-conseillent-les-collectivites"
-            data-test-id="documentation-button-advisor">Documentation</a>
+            data-test-id="documentation-button-advisor" target="_blank">Documentation</a>
           </li>
           <li>
             <hr class="dropdown-divider">


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Changement des liens de la documentation admin de portail et conseiller d'un projet dans le menu déroulant au clique sur son compte.
Changement du type de lien pour s'ouvrir vers un nouvel onglet.

[Lien ticket github project](https://github.com/betagouv/recommandations-collaboratives/issues/495)

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
