### PR TITLE
[fix] update kanban page title

### DIFF
--- a/recoco/apps/projects/templates/projects/project/list-kanban.html
+++ b/recoco/apps/projects/templates/projects/project/list-kanban.html
@@ -19,7 +19,7 @@
           type="text/css">
 {% endblock css %}
 {% block title %}
-    Tableau de bord adstrateur {{ block.super }}
+    Tableau de bord administrateur {{ block.super }}
 {% endblock title %}
 {% block project_list_content %}
     <div x-data="KanbanProjects({{ request.site.id }})">


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Modification du titre de la page du kanban.

Avant : 
![image](https://github.com/user-attachments/assets/4ad48227-afca-4945-88d9-f4e83441f69c)

Après : 
![image](https://github.com/user-attachments/assets/fc74afc5-6bb7-45cb-bd29-f2b540a75188)


## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
