### PR TITLE
[fix] update gravatar z-index to show correctly the dropdown menu on …

### DIFF
--- a/recoco/templates/default_site/actstream/action.html
+++ b/recoco/templates/default_site/actstream/action.html
@@ -5,12 +5,11 @@
 {% get_verbs as verbs %}
 <div class="d-block font-marianne">
   <div class="d-flex align-items-start mb-2">
-    <img class="mt-1 align-middle rounded-circle d-inline-block {% if not transparent_background %}bg-white{% endif %}"
+    <img class="mt-1 z-3 align-middle rounded-circle d-inline-block {% if not transparent_background %}bg-white{% endif %}"
          width="18px"
          :src='$store.utils.gravatar_url("{{ action.actor }}", 18, "{{ action.actor.first_name }}" + " " + "{{ action.actor.last_name }}")'
          data-bs-toggle="tooltip"
          data-bs-placement="bottom"
-         style="z-index: 1000"
          tabindex="0">
     <div class="mt-1 ms-1 font-very-small"
          data-test-id="project-activity-notification">


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Modification de z-index des gravatars pour passer de 1000 à 3 en changeant le css inline en une classe bootstrap.

[Lien ticket Github projects associé](https://github.com/betagouv/recommandations-collaboratives/issues/541)

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
