### PR TITLE
[fix] readme and script in package.json

### DIFF
--- a/frontend_tests/README.md
+++ b/frontend_tests/README.md
@@ -16,11 +16,28 @@ DATABASES = {
         'HOST': 'localhost',
         'PORT': 5432,
         'TEST': {
-            'NAME':'test_recoco'
+            'NAME':'test_recoco' # <-- ici
         }
     }
 }
 ```
+
+- Dupliquer le fichier `development.py` en `frontend_tests.py` et modifier les paramètres de la base de données pour qu'ils correspondent à la base de données de test.
+
+```python
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': test_recoco, # <-- ici
+        'USER': os.environ.get('POSTGRES_USER'),
+        'PASSWORD': os.environ.get('POSTGRES_PASSWORD'),
+        'HOST': 'localhost',
+        'PORT': 5432,
+    }
+}
+```
+
+Ce fichier de paramètres est seulement utilisé pour lancer la mise à jour des persmissions à l'aide du script update_permissions
 
 ## Lancer les tests
 

--- a/frontend_tests/package.json
+++ b/frontend_tests/package.json
@@ -11,7 +11,7 @@
     "django:start-server": "cross-env DJANGO_SETTINGS_MODULE=recoco.settings.development ../manage.py testserver ./cypress/fixtures/settings/siteWithOnboardingAndSurvey.json ./cypress/fixtures/users/users.json ./cypress/fixtures/geomatics/region.json ./cypress/fixtures/geomatics/department.json ./cypress/fixtures/geomatics/commune.json ./cypress/fixtures/projects/projects.json ./cypress/fixtures/projects/projectsMembers.json ./cypress/fixtures/projects/reminders.json ./cypress/fixtures/addressbook/organizations.json ./cypress/fixtures/profiles/profiles.json ./cypress/fixtures/resources/resources.json ./cypress/fixtures/addressbook/contacts.json ./cypress/fixtures/documents/documents.json --noinput",
     "frontend:start-server": "cross-env yarn --cwd ../recoco/frontend dev",
     "django:start-server-test_ui": "cross-env DJANGO_SETTINGS_MODULE=recoco.settings.development ../manage.py runserver",
-    "django:update-permissions": "cross-env DJANGO_SETTINGS_MODULE=recoco.settings.development ../manage.py update_permissions"
+    "django:update-permissions": "cross-env ../manage.py update_permissions --settings recoco.settings.frontend_tests"
   },
   "author": "",
   "license": " GPL-3.0-or-later",


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Mise à jour de la documentation pour les tests frontend. 
Finalement, le fichier de paramétrage `frontend_tests` reste nécessaire notamment pour lancer la commande `update_permissions`
Le script dans le package.json a donc été mis à jour ainsi que la documentation.

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
