### PR TITLE
[fix] change width div for summary card to avoid text overflow #372

### DIFF
--- a/recoco/apps/survey/static/survey/css/widget/qs_summary_card.scss
+++ b/recoco/apps/survey/static/survey/css/widget/qs_summary_card.scss
@@ -1,0 +1,3 @@
+.specific-width {
+  width: 90%;
+}

--- a/recoco/apps/survey/templates/survey/widgets/qs_summary_card.html
+++ b/recoco/apps/survey/templates/survey/widgets/qs_summary_card.html
@@ -7,6 +7,9 @@
     <link href="{% sass_src 'survey/css/survey.scss' %}"
           rel="stylesheet"
           type="text/css">
+    <link href="{% sass_src 'survey/css/widget/qs_summary_card.scss' %}"
+          rel="stylesheet"
+          type="text/css">
 {% endblock %}
 {% get_obj_perms request.user for request.site as "user_site_perms" %}
 {% get_obj_perms request.user for project as "user_project_perms" %}
@@ -41,7 +44,7 @@
                 <ul class="list-unstyled">
                     {% for answer in answers %}
                         <li class="answer mb-2 mt-4 d-flex justify-content-between position-relative">
-                            <div class="flex-grow-1">
+                            <div class="flex-grow-1 specific-width">
                                 {% lookup_choices_from_answer answer as choices %}
                                 {% if show_question or not choices %}
                                     <div>


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Ajout d'une largeur sur la div contenant les commentaires de réponses à létat des lieux pour éviter les dépassements de texte. 

Avant : 
![image](https://github.com/user-attachments/assets/dddb28c0-339c-485c-8cb7-06ae55840a78)

Après : 
![image](https://github.com/user-attachments/assets/871d3ca2-d65c-4085-9d9b-a6b21fa48992)

Close #372

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
