### PR TITLE
[fix] accept and become advisor in moderation page

### DIFF
--- a/recoco/apps/projects/views/__init__.py
+++ b/recoco/apps/projects/views/__init__.py
@@ -159,12 +159,12 @@ def project_moderation_accept(request, project_pk):
             join = form.cleaned_data["join"]
 
             if join:
-                # Assign current user as observer if requested
-                assign_observer(request.user, project, request.site)
+                # Assign current user as advisor if requested
+                assign_advisor(request.user, project, request.site)
                 messages.add_message(
                     request,
                     messages.INFO,
-                    f"Vous êtes maintenant observateur·rice du projet '{project.name}'.",
+                    f"Vous êtes maintenant conseiller·ère du projet '{project.name}'.",
                 )
 
         return redirect(reverse("projects-project-detail-overview", args=(project.pk,)))


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Dans la page modération : 
- Lorsque l'on click sur `Accepter et rejoindre`, l'utilisateur rejoint en tant que __conseiller__

Resolve #628 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
