### PR TITLE
[fix] duplicating portal name even if the logo is available

### DIFF
--- a/recoco/templates/default_site/header/menu-top-logo.html
+++ b/recoco/templates/default_site/header/menu-top-logo.html
@@ -39,7 +39,6 @@
                  width="auto"
                  height="40px"
                  alt="logo {{ request.site.name }} - lien retour page accueil" />
-            <span class="fw-bold span-specific-fontsize-30 specific-ml-30">{{ request.site.name }}</span>
         </a>
     </div>
 {% else %}


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Si déconnecté : le header d'un portail n'affiche plus le nom du portail à côté du logo s'il est disponible 
![Capture d’écran 2024-09-16 à 19 01 34](https://github.com/user-attachments/assets/4c998613-da87-4cf3-aeef-61ad8b8fe1de)


## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
