### PR TITLE
[feat] transform embed template view  to use data from django not fro…

### DIFF
--- a/recoco/apps/projects/templates/projects/project/actions_embed.html
+++ b/recoco/apps/projects/templates/projects/project/actions_embed.html
@@ -18,9 +18,6 @@
           rel="stylesheet"
           type="text/css" />
 {% endblock css %}
-{% block banner %}
-    {% include "projects/project/fragments/positioning_banner.html" %}
-{% endblock banner %}
 {% block project_detail %}
     {% get_obj_perms request.user for request.site as "user_site_perms" %}
     {% get_obj_perms request.user for project as "user_project_perms" %}
@@ -37,35 +34,11 @@
                         <p class="fst-italic fw-light">
                             Soyez la première personne à proposer des recommandations ou des ressources à la collectivité !
                         </p>
-                        {% if advising %}
-                            <a data-test-id="submit-task-button"
-                               href="{% url 'projects-project-create-task' project.id %}"
-                               class="btn btn-primary">Émettre une
-                            recommandation</a>
-                            <a href="{% url 'projects-project-detail-knowledge' project.id %}"
-                               class="btn btn-secondary">Consulter
-                            les détails du projet</a>
-                            <p class="mt-3">
-                                <span class="badge bg-warning">Beta feature</span> <a href="{% url 'projects-project-tasks-suggest' project.pk %}">Examiner les recommandation suggérées
-                                automatiquement pour ce projet</a>
-                            </p>
-                        {% else %}
-                            <a href="{% url 'projects-project-switchtender-join' project.id %}"
-                               class="btn btn-primary">Rejoindre ce
-                            projet pour l'aiguiller</a>
-                        {% endif %}
                     </div>
                 {% elif not is_switchtender and project.tasks.public.count == 0 %}
                     <div class="bg-light p-4 rounded-2">
                         <h3 class="fw-light">Vous n'avez pas de recommandations en cours</h3>
                         <p class="fst-italic fw-light">Des recommandations vous seront proposées par notre équipe dès que possible.</p>
-                        <p class="fst-italic fw-light">
-                            Vous pouvez accélerer les recommandations <span class="fw-bolder">en complétant le questionnaire
-                            d'exploration</span>.
-                        </p>
-                        <a href="{% url 'survey-project-session' project.id %}"
-                           class="btn btn-primary">Compléter le
-                        questionnaire d'exploration</a>
                     </div>
                 {% else %}
                     {% include "projects/project/fragments/tasks_inline_kanban/tasks_inline_kanban.html" with embed_view=True %}

--- a/recoco/apps/projects/templates/projects/project/fragments/task/task_comment.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/task/task_comment.html
@@ -1,9 +1,9 @@
 {% load static %}
 <div x-data="TaskComment()">
-    <template x-if="task.content !== '' && !isEditing">
+    <template x-if="currentTask.content !== '' && !isEditing">
         <div data-test-id="task-initial-comment"
              class="position-relative fr-p-2w bg-grey-light rounded-3 fr-p-2w">
-            <div x-html="truncate(renderMarkdown(task.content),100)"
+            <div x-html="truncate(renderMarkdown(currentTask.content),100)"
                  class="text-info-custom font-small text-dark fr-mb-2w"></div>
             {% include "projects/project/fragments/task/task_user_card.html" %}
             {% if embed_view is not True %}
@@ -17,7 +17,7 @@
             {% endif %}
         </div>
     </template>
-    <template x-if="!isEditing && task.content === ''">
+    <template x-if="!isEditing && currentTask.content === ''">
         <div class="rounded bg-grey-light fr-mb-3w fr-px-2w d-flex flex-column fr-py-2w justify-content-between align-items-start task-item position-relative">
             <div class="d-flex flex-column align-items-center justify-content-center w-100 fr-py-3w">
                 <span class="text-info-custom text-orange name fw-normal fr-mb-2v">Pas de commentaire initial</span>

--- a/recoco/apps/projects/templates/projects/project/fragments/task/task_user_card.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/task/task_user_card.html
@@ -9,7 +9,7 @@
 {% block js %}
     {% vite_asset 'js/apps/user.js' %}
 {% endblock js %}
-<div x-data="User(task.created_by)"
+<div x-data="User(currentTask.created_by)"
      class="user-card position-relative d-flex fr-my-1v flex-column justify-content-between align-items-start">
     <div class="position-relative d-flex align-items-center justify-content-between">
         <div x-ref="user"

--- a/recoco/apps/projects/templates/projects/project/fragments/tasks_inline/task_item_embed.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/tasks_inline/task_item_embed.html
@@ -1,0 +1,73 @@
+{% load static %}
+{% load gravatar %}
+{% load guardian_tags %}
+{% load sass_tags %}
+{% block css %}
+    <link href="{% sass_src 'projects/css/fragments/task_inline/task.scss' %}"
+          rel="stylesheet"
+          type="text/css" />
+{% endblock css %}
+{% get_obj_perms request.user for request.site as "user_site_perms" %}
+{% get_obj_perms request.user for project as "user_project_perms" %}
+<div x-data="Task({id:{{ task.id }}, public:Boolean(`{{ task.public }}`), topic:{name :`{{ task.topic }}` == `None` ? null : `{{ task.topic }}`}, intent:`{{ task.intent }}`, resource:`{{ task.resource }}`, ds_folder:`{{ task.ds_folder }}`, comments_count:Number(`{{ task.comments_count }}`), content:`{{ task.content }}`, created_by:{ email : `{{ task.created_by.email }}`, first_name: `{{ task.created_by.first_name }}`, last_name: `{{ task.created_by.last_name }}`, is_active: Boolean(`{{ task.created_by.is_active }}`), profile : {organization: { name: `{{ task.created_by.profile.organization.name }}` }}}  })"
+     :class="`border${getTaskColor(currentTask)}`"
+     class="rounded fr-mb-2w fr-px-2w d-flex fr-pt-2w fr-pb-2w justify-content-between align-items-start task-item hover-shadow hover-border-blue transition-all"
+     :id="currentTask.id">
+    <div class="d-flex flex-column flex-grow-1 ease-transition tmp-usevar">
+        <div data-test-id="badge-new-task"
+             class="card-top-information d-flex align-items-center">
+            <template x-if="!currentTask.public">
+                <div class="left-0">
+                    <span data-test-id="task-draft-status"
+                          :class="`bg${getTaskColor(currentTask)}`"
+                          class="text-dark">Brouillon</span>
+                </div>
+            </template>
+            <template x-if="currentTask.topic && currentTask.topic.name ">
+                <div class="left-0 fr-ml-2v">
+                    <span data-test-id="task-inline-topic"
+                          class="bg-purple text-white"
+                          x-text="currentTask.topic.name"></span>
+                </div>
+            </template>
+        </div>
+        <div class="d-flex align-items-center justify-content-between">
+            <div class="d-flex w-100 justify-content-between align-items-center">
+                <div class="d-flex w-100 align-items-center">
+                    <h4 class="fr-mt-0 fr-pt-0 fr-mb-0 fw-bold fr-mb-3v"
+                        x-text="currentTask.intent"></h4>
+                </div>
+            </div>
+        </div>
+        <template x-if="currentTask.resource">
+            <article>{% include "projects/project/fragments/task/task_comment.html" %}</article>
+        </template>
+        <template x-if="currentTask.ds_folder">
+            <hr class="fr-mt-3w">
+            <div>
+                <h4 class="fw-bolder">
+                    <img height="31px"
+                         width="32px"
+                         src="{% static 'svg/picto-demarches_simplifiees.svg' %}"
+                         alt="Pictogramme Démarches Simplifiées">
+                    Dossier Démarches Simplifiées
+                </h4>
+                <p class="fr-text-mention--grey fr-text--sm fr-my-3v">
+                    Complétez l’état des lieux pour pré-remplir automatiquement le dossier de candidature.
+                </p>
+                <a class="fr-btn fr-btn--secondary fr-btn--sm"
+                   @click.stop=""
+                   x-bind:href="currentTask.ds_folder.dossier_url">Voir mon dossier</a>
+                <span class="fr-ml-2w fr-text-label--blue-france fr-text--xs">
+                    {% if task.ds_folder.prefilled_count > 1 %}
+                        {{ task.ds_folder.prefilled_count }} données pré-remplies
+                    {% elif task.ds_folder.prefilled_count > 0 %}
+                        1 donnée pré-remplie
+                    {% else %}
+                        aucune donnée pré-remplie
+                    {% endif %}
+                </span>
+            </div>
+        </template>
+    </div>
+</div>

--- a/recoco/apps/projects/templates/projects/project/fragments/tasks_inline/task_list.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/tasks_inline/task_list.html
@@ -1,11 +1,19 @@
-<template x-for="(task, i) in column(board.status)" :key="task.id">
-    <div class="task-animation-appear-in position-relative fr-my-3w tmp-usevar"
-         :style="`z-index:${10000-i}`">{% include "projects/project/fragments/tasks_inline/task_item.html" %}</div>
-</template>
-<div x-show="column(board.status).length == '0'">
-    <div class="border rounded fr-mb-2w fr-px-2w d-flex fr-pt-2w fr-pb-2w justify-content-between align-items-start task-item">
-        <p class="text-info-custom font-small text-grey-dark fr-my-0"
-           x-text="filterIsDraft == true ? 'Aucune recommandation en brouillon' : 'Aucune recommandation dans cette catégorie'">
-        </p>
+{% if embed_view is not True %}
+    <template x-for="(task, i) in column(board.status)" :key="task.id">
+        <div class="task-animation-appear-in position-relative fr-my-3w tmp-usevar"
+             :style="`z-index:${10000-i}`">{% include "projects/project/fragments/tasks_inline/task_item.html" %}</div>
+    </template>
+    <div x-show="column(board.status).length == '0'">
+        <div class="border rounded fr-mb-2w fr-px-2w d-flex fr-pt-2w fr-pb-2w justify-content-between align-items-start task-item">
+            <p class="text-info-custom font-small text-grey-dark fr-my-0"
+               x-text="filterIsDraft == true ? 'Aucune recommandation en brouillon' : 'Aucune recommandation dans cette catégorie'">
+            </p>
+        </div>
     </div>
-</div>
+{% else %}
+    {% for task in actions %}
+        <div class="task-animation-appear-in position-relative fr-my-3w tmp-usevar">
+            {% include "projects/project/fragments/tasks_inline/task_item_embed.html" with task=task task_id=task.id %}
+        </div>
+    {% endfor %}
+{% endif %}

--- a/recoco/apps/projects/templates/projects/project/fragments/tasks_inline_kanban/tasks_inline_kanban.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/tasks_inline_kanban/tasks_inline_kanban.html
@@ -1,7 +1,11 @@
 {% load django_vite %}
-{% block project_js %}
-    {% vite_asset 'js/apps/tasks.js' %}
-{% endblock project_js %}
+{% block js %}
+    {% if embed_view is not True %}
+        {% vite_asset 'js/apps/tasks.js' %}
+    {% else %}
+        {% vite_asset 'js/apps/tasksEmbed.js' %}
+    {% endif %}
+{% endblock js %}
 {{ project.pk|json_script:"djangoProjectId" }}
 {{ can_administrate|json_script:"canAdministrate" }}
 {{ user_project_perms|json_script:"userProjectPerms" }}
@@ -15,7 +19,9 @@
     <template x-if="$store.tasksView.currentView === 'kanban'">
         {% include "projects/project/fragments/tasks_kanban/tasks_kanban.html" %}
     </template>
-    {% include "projects/project/fragments/tasks_modal/task_modal.html" %}
-    {% include "projects/project/fragments/tasks_modal/delete_task_confirmation_modal.html" %}
-    {% include "projects/project/fragments/tasks_modal/feedback_modal.html" %}
+    {% if embed_view is not True %}
+        {% include "projects/project/fragments/tasks_modal/task_modal.html" %}
+        {% include "projects/project/fragments/tasks_modal/delete_task_confirmation_modal.html" %}
+        {% include "projects/project/fragments/tasks_modal/feedback_modal.html" %}
+    {% endif %}
 </div>

--- a/recoco/apps/projects/templates/projects/project/fragments/tasks_inline_kanban/tasks_inline_kanban_header.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/tasks_inline_kanban/tasks_inline_kanban_header.html
@@ -28,5 +28,7 @@
             </div>
         </template>
     </div>
-    {% include "projects/project/fragments/tasks_inline_kanban/tasks_inline_kanban_new_tasks_banner.html" %}
+    {% if embed_view is not True %}
+        {% include "projects/project/fragments/tasks_inline_kanban/tasks_inline_kanban_new_tasks_banner.html" %}
+    {% endif %}
 </div>

--- a/recoco/apps/projects/templates/projects/project/fragments/tasks_inline_kanban/tasks_inline_kanban_tasks_count.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/tasks_inline_kanban/tasks_inline_kanban_tasks_count.html
@@ -1,4 +1,19 @@
-<div class="d-flex align-items-center fr-mr-1v fr-mb-2v">
-    <span class="fw-bold custom-info-title" data-test-id="tasks-count"
-          x-text="$store.tasksData.validatedTasks.length > 1 ? `${$store.tasksData.validatedTasks.length} recommandations` :  `${$store.tasksData.validatedTasks.length} recommandation`"></span>
-</div>
+{% if embed_view is not True %}
+    <div class="d-flex align-items-center fr-mr-1v fr-mb-2v">
+        <span class="fw-bold custom-info-title"
+              data-test-id="tasks-count"
+              x-text="$store.tasksData.validatedTasks.length > 1 ? `${$store.tasksData.validatedTasks.length} recommandations` :  `${$store.tasksData.validatedTasks.length} recommandation`"></span>
+    </div>
+{% else %}
+    <div class="d-flex align-items-center fr-mr-1v fr-mb-2v">
+        <span class="fw-bold custom-info-title" data-test-id="tasks-count">
+            {% if actions|length > 1 %}
+                {{ actions|length }} recommandations
+            {% elif actions|length > 0 %}
+                {{ actions|length }}recommandation
+            {% else %}
+                Aucune recommandation pour le moment
+            {% endif %}
+        </span>
+    </div>
+{% endif %}

--- a/recoco/frontend/src/js/apps/tasksEmbed.js
+++ b/recoco/frontend/src/js/apps/tasksEmbed.js
@@ -1,0 +1,11 @@
+import '../../css/statusSwitcher.css';
+import '../../css/tasks.css';
+
+//Store
+import '../store/tasks';
+
+//Components
+import '../components/TasksInline';
+import '../components/Task';
+import '../components/TaskComment';
+import '../components/User';

--- a/recoco/frontend/src/js/components/Task.js
+++ b/recoco/frontend/src/js/components/Task.js
@@ -7,6 +7,11 @@ import { renderMarkdown } from '../utils/markdown';
 import { gravatar_url } from '../utils/gravatar';
 import { truncate } from '../utils/taskStatus';
 
+/**
+ * Represents a Task component.
+ * @param {Object} currentTask - The current task object.
+ * @returns {Object} - The Task component object.
+ */
 export default function Task(currentTask) {
   return {
     currentTask: null,


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
- La vue embed des recommandations utilise dorénavant les données transmises par la vue Django et non les données de l'api
- La clé du projet doit être transmise dans l'url pour pouvoir afficher les informations du projet 

<img width="1200" alt="Capture d’écran 2024-09-17 à 15 38 18" src="https://github.com/user-attachments/assets/439e355f-f208-444a-b564-47fb23ed71a9">

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
