### PR TITLE
[fix] typo + map height in statistics page

### DIFF
--- a/recoco/apps/home/static/home/css/dsfr/custom-dsfr.scss
+++ b/recoco/apps/home/static/home/css/dsfr/custom-dsfr.scss
@@ -542,3 +542,7 @@ form > p {
 .text-transform-none {
   text-transform: none !important;
 }
+
+.height-fit-content {
+  height: fit-content;
+}

--- a/recoco/apps/home/static/home/css/statistics/statistics.scss
+++ b/recoco/apps/home/static/home/css/statistics/statistics.scss
@@ -5,3 +5,7 @@
 .min-height {
   min-height: 300px;
 }
+
+#friches {
+  max-height: 300px;
+}

--- a/recoco/apps/home/templates/home/statistics.html
+++ b/recoco/apps/home/templates/home/statistics.html
@@ -109,7 +109,7 @@
             <div class="col align-content-stretch d-flex">
                 <div class="rounded-4 border border-1 fr-p-3w fr-mb-3w text-center w-100">
                     <h4 class="fw-bold fr-mb-2v">Sollicitations de nouvelles friches</h4>
-                    <div id="chart-new">
+                    <div id="chart-new" class="d-flex align-items-center h-100 ">
                         <svg class="w-100 min-height">
                         </svg>
                     </div>

--- a/recoco/apps/home/templates/home/statistics.html
+++ b/recoco/apps/home/templates/home/statistics.html
@@ -88,12 +88,12 @@
                 des collectivités utilisatrices du service agissent sur la base des recommandations qu'elles ont reçu sur UrbanVitaliz
             </h2>
             <p>
-                Notre impact est atteint lorsqu'une collectivité entreprend une recommandations. Les collectivités actionnent ces recommandations sous quelques semaines à quelques mois, selon leur disponibilité et leur agenda politique.
+                Notre impact est atteint lorsqu'une collectivité entreprend une recommandation. Les collectivités actionnent ces recommandations sous quelques semaines à quelques mois, selon leur disponibilité et leur agenda politique.
             </p>
         </div>
         <div class="row row-cols-xl-2 row-cols-1">
             <div class="col align-content-stretch d-flex">
-                <div class="rounded-4 border border-1 fr-p-3w fr-mb-3w text-center w-100">
+                <div class="rounded-4 border border-1 fr-p-3w fr-mb-3w text-center w-100 height-fit-content">
                     <h4 class="fw-bold fr-mb-2v">Sites accompagnés et recommandations</h4>
                     <p class="text-start">
                         <ul class="text-start">
@@ -111,7 +111,6 @@
                     <h4 class="fw-bold fr-mb-2v">Sollicitations de nouvelles friches</h4>
                     <div id="chart-new">
                         <svg class="w-100 min-height">
-                            >
                         </svg>
                     </div>
                 </div>


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
- Réglage de la hauteur de la map
- Réglage de la hauteur du graphique
- Correction d'une type

<img width="1436" alt="Capture d’écran 2024-09-24 à 10 54 23" src="https://github.com/user-attachments/assets/e36b4ec5-c05e-4644-97e7-b42499e0d39c">

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
