### PR TITLE
[fix] kanban overflow + BEM css style

### DIFF
--- a/recoco/apps/projects/static/projects/css/kanban.scss
+++ b/recoco/apps/projects/static/projects/css/kanban.scss
@@ -14,12 +14,7 @@
     min-height: 100px;
     background-color: #f6f6f6;
 
-    &--title-container {
-      border-top-left-radius: 4px;
-      border-top-right-radius: 4px;
-    }
-
-    &--content {
+    &__content {
       height: 60vh;
       overflow-x: hidden;
       overflow-y: auto;
@@ -39,7 +34,7 @@
     background-color: #fafafa;
     box-shadow: 2px 2px 4px 0px #0000001a;
 
-    &--state {
+    &__state {
       &-container {
         display: flex;
         position: absolute;
@@ -47,7 +42,7 @@
         gap: 0.8rem;
       }
 
-      &__pause {
+      &--pause {
         padding: 0.25rem 0.5rem;
         font-size: 12px;
         text-transform: uppercase;
@@ -58,25 +53,25 @@
       }
     }
 
-    &--border {
-      &__is-switchtender {
+    &__border {
+      &--is-switchtender {
         border: 1px solid #0063cb;
         background-color: white;
       }
 
-      &__is-observer {
+      &--is-observer {
         border: 1px solid #27a658;
         background-color: white;
       }
     }
 
-    &--notification {
+    &__notification {
       &-container {
         transform: translate(-65%, -75%) !important;
       }
     }
 
-    &--commune {
+    &__commune {
       &-container {
         margin-top: 2px;
         color: #3a3a3a;
@@ -91,9 +86,11 @@
       }
     }
 
-    &--project {
+    &__project {
       &-container {
         margin-top: -5px;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       &-push-by-container,
@@ -109,6 +106,7 @@
         font-size: 14px;
         font-weight: 400;
         font-family: 'Marianne';
+        white-space: nowrap;
       }
 
       &-date-container {

--- a/recoco/apps/projects/templates/projects/project/list-kanban.html
+++ b/recoco/apps/projects/templates/projects/project/list-kanban.html
@@ -51,7 +51,7 @@
                                     <div class="d-flex justify-content-between justify-items-center fr-px-2v fr-py-2v sticky top-0">
                                         <h5 x-text="board.title" class="font-medium text-gray-800 fr-mb-0"></h5>
                                     </div>
-                                    <div class="kanban-column--content">
+                                    <div class="kanban-column__content">
                                         <div class="fr-px-2v fr-py-1v fr-pb-1v h-100">
                                             <template x-if="column(board.code).length === 0">
                                                 <div class="drag-targetable fr-py-2v h-100"
@@ -79,32 +79,31 @@
                                                      @dragend="onDragEnd(event)">
                                                     <a :href="makeProjectURL(t.id)">
                                                         <div class="kanban-card rounded fr-p-2v w-100 position-relative"
-                                                             :class="{'kanban-card--border__is-switchtender': t.is_switchtender, 'kanban-card--border__is-observer': t.is_observer}"
+                                                             :class="{'kanban-card__border--is-switchtender': t.is_switchtender, 'kanban-card__border--is-observer': t.is_observer}"
                                                              draggable="true"
                                                              :data-test-id="`item-draggable-${taskIndex}`">
                                                             <template x-if="t.inactive_since !== null">
-                                                                <div class="kanban-card--state-container">
+                                                                <div class="kanban-card__state-container">
                                                                     <div class="left-0">
-                                                                        <div class="kanban-card--state__pause">En pause</div>
+                                                                        <div class="kanban-card__state--pause">En pause</div>
                                                                     </div>
                                                                 </div>
                                                             </template>
                                                             <template x-if="t.notifications.count > 0">
-                                                                <span class="kanban-card--notification-container position-absolute top-25 start-100 badge bg-info"
+                                                                <span class="kanban-card__notification-container position-absolute top-25 start-100 badge bg-info"
                                                                       :class="{'bg-danger': t.notifications.has_collaborator_activity == true}"><span x-text="t.notifications.count"></span> <span class="visually-hidden">nouvelle activité</span></span>
                                                             </template>
                                                             <template x-if="t.commune">
-                                                                <div class="kanban-card--commune-container fw-bold">
-                                                                    <span class="kanban-card--commune-name" x-text="t.commune.name"></span>
-                                                                    <span class="kanban-card--commune-postal" x-text="`(${t.commune.postal})`"></span>
+                                                                <div class="kanban-card__commune-container fw-bold">
+                                                                    <span class="kanban-card__commune-name" x-text="t.commune.name"></span>
+                                                                    <span class="kanban-card__commune-postal" x-text="`(${t.commune.postal})`"></span>
                                                                 </div>
                                                             </template>
-                                                            <div class="kanban-card--project-container fw-semibold fr-mb-2v">
-                                                                <span class="kanban-card--project-name project-link"
-                                                                      x-text="truncate(t.name)"></span>
+                                                            <div class="kanban-card__project-container fw-semibold fr-mb-2v">
+                                                                <span class="kanban-card__project-name project-link" x-text="t.name"></span>
                                                             </div>
                                                             <template x-if="t.origin">
-                                                                <div class=" kanban-card--project-push-by-container"
+                                                                <div class=" kanban-card__project-push-by-container"
                                                                      x-show="t.origin && {{ site_config.id }} !== t.origin?.site">
                                                                     <img x-show="t.origin.siteInfo.configuration.logo_small"
                                                                          :src="t.origin.siteInfo.configuration.logo_small"
@@ -119,12 +118,12 @@
                                                                 </div>
                                                             </template>
                                                             <div>
-                                                                <span class="kanban-card--project-insee fr-icon--sm fr-icon-map-pin-2-line not-a-link">INSEE: <span x-text="truncate(t.commune.insee)"></span></span>
+                                                                <span class="kanban-card__project-insee fr-icon--sm fr-icon-map-pin-2-line not-a-link">INSEE: <span x-text="truncate(t.commune.insee)"></span></span>
                                                             </div>
                                                             <div class="d-flex justify-content-between">
-                                                                <div class="kanban-card--project-date-container text-secondary">
+                                                                <div class="kanban-card__project-date-container text-secondary">
                                                                     <span x-text="`Déposé le ${formatDateDisplay(t.created_on)}`"
-                                                                          class="kanban-card--project-date fr-icon--sm fr-icon-calendar-event-line align-middle not-a-link"></span>
+                                                                          class="kanban-card__project-date fr-icon--sm fr-icon-calendar-event-line align-middle not-a-link"></span>
                                                                 </div>
                                                                 <div class="d-flex justify-content-end fr-mr-1v">
                                                                     <template x-for="switchtender in t.switchtenders">


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Le nom des projets reste maintenant sur 1 seul ligne,mais est correctement coupé.

<img width="588" alt="Capture d’écran 2024-09-25 à 20 15 59" src="https://github.com/user-attachments/assets/5dfa5a5d-cd0a-44f8-afb6-32ac01b34a82">

Resolve #614 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
