### PR TITLE
[fix] kanban staff falsy publish mention

### DIFF
--- a/recoco/apps/projects/static/projects/css/kanban.scss
+++ b/recoco/apps/projects/static/projects/css/kanban.scss
@@ -91,7 +91,7 @@
       }
     }
 
-    &--project {
+    &__project {
       &-container {
         margin-top: -5px;
       }

--- a/recoco/apps/projects/templates/projects/project/list-kanban.html
+++ b/recoco/apps/projects/templates/projects/project/list-kanban.html
@@ -99,12 +99,12 @@
                                                                     <span class="kanban-card--commune-postal" x-text="`(${t.commune.postal})`"></span>
                                                                 </div>
                                                             </template>
-                                                            <div class="kanban-card--project-container fw-semibold fr-mb-2v">
-                                                                <span class="kanban-card--project-name project-link"
+                                                            <div class="kanban-card__project-container fw-semibold fr-mb-2v">
+                                                                <span class="kanban-card__project-name project-link"
                                                                       x-text="truncate(t.name)"></span>
                                                             </div>
                                                             <template x-if="t.origin">
-                                                                <div class=" kanban-card__project-push-by-container"
+                                                                <div class="kanban-card__project-push-by-container"
                                                                      x-show="t.origin && {{ site_config.site_id }} !== t.origin?.site">
                                                                     <img x-show="t.origin.siteInfo.configuration.logo_small"
                                                                          :src="t.origin.siteInfo.configuration.logo_small"
@@ -118,13 +118,29 @@
                                                                     <span x-text="t.origin.siteInfo.name"></span>
                                                                 </div>
                                                             </template>
+                                                            <template x-for="portal in t.publishTo">
+                                                                <template x-if="portal.site !== {{ site_config.site_id }}">
+                                                                    <div class="kanban-card__project-push-by-container">
+                                                                        <img x-show="portal.siteInfo.configuration.logo_small"
+                                                                             :src="portal.siteInfo.configuration.logo_small"
+                                                                             width="16px"
+                                                                             height="auto"
+                                                                             :alt="`Logo ${portal.siteInfo.name}`" />
+                                                                        <span x-show="!portal.siteInfo.configuration.logo_small"
+                                                                              class="fr-icon--sm fr-icon-window-line"
+                                                                              aria-hidden="true"></span>
+                                                                        <span class="not-a-link kanban">projet envoyé sur</span>
+                                                                        <span x-text="portal.siteInfo.name"></span>
+                                                                    </div>
+                                                                </template>
+                                                            </template>
                                                             <div>
-                                                                <span class="kanban-card--project-insee fr-icon--sm fr-icon-map-pin-2-line not-a-link">INSEE: <span x-text="truncate(t.commune.insee)"></span></span>
+                                                                <span class="kanban-card__project-insee fr-icon--sm fr-icon-map-pin-2-line not-a-link">INSEE: <span x-text="truncate(t.commune.insee)"></span></span>
                                                             </div>
                                                             <div class="d-flex justify-content-between">
-                                                                <div class="kanban-card--project-date-container text-secondary">
+                                                                <div class="kanban-card__project-date-container text-secondary">
                                                                     <span x-text="`Déposé le ${formatDateDisplay(t.created_on)}`"
-                                                                          class="kanban-card--project-date fr-icon--sm fr-icon-calendar-event-line align-middle not-a-link"></span>
+                                                                          class="kanban-card__project-date fr-icon--sm fr-icon-calendar-event-line align-middle not-a-link"></span>
                                                                 </div>
                                                                 <div class="d-flex justify-content-end fr-mr-1v">
                                                                     <template x-for="switchtender in t.switchtenders">

--- a/recoco/apps/projects/templates/projects/project/list-kanban.html
+++ b/recoco/apps/projects/templates/projects/project/list-kanban.html
@@ -104,8 +104,8 @@
                                                                       x-text="truncate(t.name)"></span>
                                                             </div>
                                                             <template x-if="t.origin">
-                                                                <div class=" kanban-card--project-push-by-container"
-                                                                     x-show="t.origin && {{ site_config.id }} !== t.origin?.site">
+                                                                <div class=" kanban-card__project-push-by-container"
+                                                                     x-show="t.origin && {{ site_config.site_id }} !== t.origin?.site">
                                                                     <img x-show="t.origin.siteInfo.configuration.logo_small"
                                                                          :src="t.origin.siteInfo.configuration.logo_small"
                                                                          width="16px"

--- a/recoco/frontend/src/js/store/projects.js
+++ b/recoco/frontend/src/js/store/projects.js
@@ -32,7 +32,18 @@ Alpine.store('projects', {
       project.currentSite = project.project_sites.find(
         (projectSite) => projectSite.site === currentSiteId
       );
+      project.publishTo = project.project_sites
+        .filter((projectSite) => !projectSite.is_origin)
+        .map((projectSite) => {
+          return {
+            ...projectSite,
+            siteInfo: this.sitesConfig.find(
+              (site) => site.id === projectSite.site
+            ),
+          };
+        });
     });
+    console.log(projects);
 
     return projects;
   },

--- a/recoco/frontend/src/js/store/projects.js
+++ b/recoco/frontend/src/js/store/projects.js
@@ -43,7 +43,6 @@ Alpine.store('projects', {
           };
         });
     });
-    console.log(projects);
 
     return projects;
   },


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
- Résolution du bug qui affichait à tort tous les projets de EQ publié à partir d'une autre portail.

<img width="1485" alt="Capture d’écran 2024-09-25 à 21 39 48" src="https://github.com/user-attachments/assets/037f3667-58a1-4ca6-b9a6-1f6c4ae3e34f">

Resolve #686 

- Ajout de la mention  "Envoyé sur" sur le portail A lorqu'un projet est publié vers un autre portail  
<img width="321" alt="Capture d’écran 2024-09-25 à 22 17 24" src="https://github.com/user-attachments/assets/229ae6ba-9937-4a1d-90f9-1db0efed97c7">
<img width="328" alt="Capture d’écran 2024-09-25 à 22 18 22" src="https://github.com/user-attachments/assets/277d4383-9b2c-4178-94e6-22c802248bf7">

Resolve #629 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
