### PR TITLE
[fix] close button modal previz, badge category

### DIFF
--- a/recoco/apps/projects/templates/projects/project/fragments/action_pusher/resource_search.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/action_pusher/resource_search.html
@@ -64,12 +64,12 @@
                              aria-hidden="true">
                             <div class="modal-dialog modal-fullscreen">
                                 <div class="modal-content">
-                                    <div class="modal-header">
+                                    <div class="modal-header justify-content-between">
                                         <h5 class="modal-title">Prévisualisation de la ressource</h5>
                                         <button type="button"
-                                                class="btn-close"
+                                                class="fr-btn fr-btn-close"
                                                 data-bs-dismiss="modal"
-                                                aria-label="Close"></button>
+                                                aria-label="Close">Fermer</button>
                                     </div>
                                     <div class="modal-body">
                                         <iframe class="w-100 h-100" :src="resource.url_embeded"></iframe>
@@ -79,10 +79,12 @@
                         </div>
                         <div>
                             <ul class="fr-badge-group fr-p-0">
-                                <li x-show="resource.category.name">
-                                    <span class="fr-badge fr-badge--sm fr-badge--green-menthe"
-                                          x-text="resource.category.name"></span>
-                                </li>
+                                <template x-if="resource.category && resource.category.name">
+                                    <li>
+                                        <span class="fr-badge fr-badge--sm fr-badge--green-menthe"
+                                              x-text="resource.category.name"></span>
+                                    </li>
+                                </template>
                                 <li x-show="resource.is_dsresource">
                                     <span class="fr-badge fr-badge--sm text-transform-none">
                                         <img height="8px"


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Lors de la prévisualisation d'une ressource dans le pousse reco, une régression empêchait la conseillère de fermer la modal. 
 
<img width="746" alt="Capture d’écran 2024-10-15 à 10 39 30" src="https://github.com/user-attachments/assets/8d8fc2d5-2221-4be0-92b4-07c253356eed">

Resolve #719 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
