### PR TITLE
Ajout nom portail d'origine sur la page de modération

### DIFF
--- a/recoco/apps/projects/static/projects/css/project_moderation.scss
+++ b/recoco/apps/projects/static/projects/css/project_moderation.scss
@@ -15,20 +15,16 @@
   &__title {
     font-size: 16px;
     text-align: left;
+    line-height: 1rem;
+    margin-bottom: 0.75rem;
   }
   &__city {
     font-weight: 700;
-    line-height: 24px;
     color: #3a3a3a;
-    text-decoration: underline;
-    text-decoration-color: #3a3a3a;
   }
   &__name {
     font-weight: 400;
-    line-height: 22px;
     color: #666666;
-    text-decoration: underline;
-    text-decoration-color: #666666;
   }
   &__keyinfo,
   &__address,
@@ -42,6 +38,11 @@
     flex-direction: column;
     font-weight: 400;
     line-height: 24px;
+  }
+  &__location {
+    p {
+      line-height: 18px;
+    }
   }
   &__address,
   &__team {

--- a/recoco/apps/projects/templates/projects/projects_moderation.html
+++ b/recoco/apps/projects/templates/projects/projects_moderation.html
@@ -36,7 +36,7 @@
                     {% for project in draft_projects %}
                         <div class="card fr-mb-2w d-flex flex-row project-card">
                             <div class="project-card__col--left project-card__col__padding d-flex flex-column">
-                                <h3 class="project-card__title fr-mb-0">
+                                <h3 class="project-card__title">
                                     <a href="{% url 'projects-project-detail' project.id %}">
                                         {% if project.commune %}
                                             <span class="project-card__city">{{ project.commune.name }}({{ project.commune.postal|slice:2 }})</span>
@@ -45,33 +45,48 @@
                                     </a>
                                 </h3>
                                 <p class="project-card__keyinfo fr-mb-2v">
+                                    {% if project.project_sites.origin.site != request.site %}
+                                        <span>
+                                            {% if project.project_sites.origin.site.configuration.logo_small %}
+                                                <img src="{{ project.project_sites.origin.site.configuration.logo_small.url }}"
+                                                     width="16px"
+                                                     height="auto"
+                                                     alt="Logo {{ project.project_sites.origin.site.name }}" />
+                                            {% else %}
+                                                <span class="fr-icon--sm fr-icon-window-line" aria-hidden="true"></span>
+                                            {% endif %}
+                                            projet envoyé par {{ project.project_sites.origin.site.name }}
+                                        </span>
+                                    {% endif %}
                                     {% if project.commune %}
                                         <span class="fr-icon--sm fr-icon-map-pin-2-line">INSEE: {{ project.commune.insee }}</span>
                                     {% endif %}
                                     <span class="fr-icon--sm fr-icon-calendar-event-line">déposé depuis {{ project.created_on|timesince }}</span>
                                 </p>
-                                <h4 class="text-uppercase project-card__address fr-mb-0">Localisation</h4>
-                                {% if project.location and project.commune %}
-                                    <p>
-                                        <span class="fr-icon--sm fr-icon-map-pin-2-line project-card__location"
-                                              id="no-margin">{{ project.location }}</span>
-                                    </p>
-                                    <p class="fr-mb-2v">
-                                        <span class="project-card__communename">{{ project.commune.postal }} {{ project.commune.name }}</span>
-                                    </p>
-                                {% elif project.location %}
-                                    <p class="fr-mb-2v">
-                                        <span class="fr-icon--sm fr-icon-map-pin-2-line project-card__location">{{ project.location }}</span>
-                                    </p>
-                                {% elif project.commune %}
-                                    <p class="fr-mb-2v">
-                                        <span class="fr-icon--sm fr-icon-map-pin-2-line project-card__location">{{ project.commune.postal }} {{ project.commune.name }}</span>
-                                    </p>
-                                {% else %}
-                                    <p class="fr-mb-2v">
-                                        <span class="fr-icon--sm fr-icon-map-pin-2-line project-card__location">Non renseigné</span>
-                                    </p>
-                                {% endif %}
+                                <div class="project-card__location">
+                                    <h4 class="text-uppercase project-card__address fr-mb-0">Localisation</h4>
+                                    {% if project.location and project.commune %}
+                                        <p>
+                                            <span class="fr-icon--sm fr-icon-map-pin-2-line project-card__location"
+                                                  id="no-margin">{{ project.location }}</span>
+                                        </p>
+                                        <p class="fr-mb-2v">
+                                            <span class="project-card__communename">{{ project.commune.postal }} {{ project.commune.name }}</span>
+                                        </p>
+                                    {% elif project.location %}
+                                        <p class="fr-mb-2v">
+                                            <span class="fr-icon--sm fr-icon-map-pin-2-line project-card__location">{{ project.location }}</span>
+                                        </p>
+                                    {% elif project.commune %}
+                                        <p class="fr-mb-2v">
+                                            <span class="fr-icon--sm fr-icon-map-pin-2-line project-card__location">{{ project.commune.postal }} {{ project.commune.name }}</span>
+                                        </p>
+                                    {% else %}
+                                        <p class="fr-mb-2v">
+                                            <span class="fr-icon--sm fr-icon-map-pin-2-line project-card__location">Non renseigné</span>
+                                        </p>
+                                    {% endif %}
+                                </div>
                                 <h4 class="text-uppercase project-card__team fr-mb-0">Équipe collectivité</h4>
                                 <div>
                                     {% include "projects/project/fragments/project_owner.html" with project=project %}


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Affichage du nom du portail d'origine + amélioration style

<img width="512" alt="Capture d’écran 2024-10-21 à 09 48 52" src="https://github.com/user-attachments/assets/6f6b2a76-bd9a-4406-8da3-61bc55b9d54e">

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
