### PR TITLE
Lors du partage de l'EDL, ne pas afficher les CTA de complétion et de partage 

### DIFF
--- a/recoco/apps/projects/templates/projects/project/fragments/survey_grid.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/survey_grid.html
@@ -71,27 +71,31 @@
                 {% comment %} TODO
                 - refonte modal share EDL
                 {% endcomment %}
-                <div x-data="ProjectShare" class="d-flex align-items-center">
-                    <button @click="openPublicShareModal"
-                            data-toggle="modal"
-                            data-target="#publicShareModal"
-                            {% if project.status == 'DRAFT' %}disabled{% endif %}
-                            class="fr-btn fr-btn--sm fr-btn--secondary {% if project.status == 'DRAFT' %}fr-btn--icon-left fr-icon-lock-line disabled{% endif %}">
-                        Partager l'état des lieux
-                    </button>
-                    {% include "projects/project/fragments/share/public_share_modal.html" %}
-                </div>
-            </div>
-            {% for session in project.survey_session.all %}
-                <div class="survey-card-cta">
-                    <div class="survey-card-cta__title">
-                        <span class="badge {% if session.completion < 100 %}text-bg-danger {% else %}text-bg-light{% endif %} text-bg-danger">{{ session.completion }}%</span>
-                        {{ session.survey.name }}
+                {% if "use_surveys" in user_project_perms %}
+                    <div x-data="ProjectShare" class="d-flex align-items-center">
+                        <button @click="openPublicShareModal"
+                                data-toggle="modal"
+                                data-target="#publicShareModal"
+                                {% if project.status == 'DRAFT' %}disabled{% endif %}
+                                class="fr-btn fr-btn--sm fr-btn--secondary {% if project.status == 'DRAFT' %}fr-btn--icon-left fr-icon-lock-line disabled{% endif %}">
+                            Partager l'état des lieux
+                        </button>
+                        {% include "projects/project/fragments/share/public_share_modal.html" %}
                     </div>
-                    <a class="fr-btn fr-btn--sm"
-                       href="{% url 'survey-project-session' project_id=project.pk site_id=session.survey.site.id %}">Compléter le questionnaire</a>
-                </div>
-            {% endfor %}
+                {% endif %}
+            </div>
+            {% if "use_surveys" in user_project_perms %}
+                {% for session in project.survey_session.all %}
+                    <div class="survey-card-cta">
+                        <div class="survey-card-cta__title">
+                            <span class="badge {% if session.completion < 100 %}text-bg-danger {% else %}text-bg-light{% endif %} text-bg-danger">{{ session.completion }}%</span>
+                            {{ session.survey.name }}
+                        </div>
+                        <a class="fr-btn fr-btn--sm"
+                           href="{% url 'survey-project-session' project_id=project.pk site_id=session.survey.site.id %}">Compléter le questionnaire</a>
+                    </div>
+                {% endfor %}
+            {% endif %}
             <div class="fr-mt-3w">
                 {% for session in project.survey_session.all %}
                     <h4>{{ session.survey.name }}</h4>


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

<img width="1509" alt="Capture d’écran 2024-10-24 à 09 20 30" src="https://github.com/user-attachments/assets/28922232-c257-4974-8e67-2734d105f80e">

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
