### PR TITLE
[fix] update banner when not observer nor advisor

### DIFF
--- a/recoco/apps/home/static/home/css/dsfr/custom-dsfr.scss
+++ b/recoco/apps/home/static/home/css/dsfr/custom-dsfr.scss
@@ -560,7 +560,8 @@ form > p {
 }
 
 .specific-border-4pxsolid000091 {
-  border: 4px solid #000091;
+  // border: 4px solid #000091;
+  border: 4px solid var(--error-425-625);
 }
 
 .specific-border-4pxsolid1e1e1e {

--- a/recoco/apps/projects/static/projects/css/fragments/project_banner/project_banner.scss
+++ b/recoco/apps/projects/static/projects/css/fragments/project_banner/project_banner.scss
@@ -24,3 +24,33 @@
   background-color: transparent !important;
   cursor: pointer;
 }
+
+@media (max-width: 1850px) {
+  .banner-container {
+    width: 60%;
+  }
+}
+
+@media (max-width: 1600px) {
+  .banner-container {
+    width: 70%;
+  }
+}
+
+@media (max-width: 1400px) {
+  .banner-container {
+    width: 80%;
+  }
+}
+
+@media (max-width: 1200px) {
+  .banner-container {
+    width: 90%;
+  }
+}
+
+@media (max-width: 1035px) {
+  .banner-container {
+    width: 100%;
+  }
+}

--- a/recoco/apps/projects/static/projects/css/fragments/project_banner/project_banner.scss
+++ b/recoco/apps/projects/static/projects/css/fragments/project_banner/project_banner.scss
@@ -14,6 +14,13 @@
   }
   &--join,
   &--non-publish {
-    background: #000091;
+    // background: #000091;
+    background: var(--error-425-625);
   }
+}
+
+.specific-hover-blue:hover {
+  color: #0063cb;
+  background-color: transparent !important;
+  cursor: pointer;
 }

--- a/recoco/apps/projects/templates/projects/project/actions.html
+++ b/recoco/apps/projects/templates/projects/project/actions.html
@@ -33,7 +33,7 @@
                 {% elif not advising and is_regional_actor and not is_staff %}
                     <div class="specific-border-4pxsolid000091">
                         {% include "projects/project/fragments/project_banner/join_project_banner.html" %}
-                        <div class="specific-opacity-02">
+                        <div>
                         {% endif %}
                         {{ can_administrate|json_script:"canAdministrate" }}
                         {{ user_project_perms|json_script:"userProjectPerms" }}

--- a/recoco/apps/projects/templates/projects/project/actions.html
+++ b/recoco/apps/projects/templates/projects/project/actions.html
@@ -12,6 +12,7 @@
 {% block js %}
     <script src="https://cdn.jsdelivr.net/npm/js-md5@0.7.3/src/md5.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    {% vite_asset 'js/store/showRole.js' %}
 {% endblock js %}
 {% block css %}
     <link href="{% sass_src 'projects/css/board.scss' %}"
@@ -31,7 +32,7 @@
                 <div class="specific-border-4pxsolid000091">
                     {% include "projects/project/fragments/project_banner/non_published_project_banner.html" %}
                 {% elif not advising and is_regional_actor and not is_staff %}
-                    <div class="specific-border-4pxsolid000091">
+                    <div x-data x-init="$nextTick(() => $store.showRole.init())" class="specific-border-4pxsolid000091">
                         {% include "projects/project/fragments/project_banner/join_project_banner.html" %}
                         <div>
                         {% endif %}

--- a/recoco/apps/projects/templates/projects/project/fragments/project_banner/join_project_banner.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/project_banner/join_project_banner.html
@@ -5,11 +5,16 @@
           type="text/css">
 {% endblock css %}
 <div class="d-flex justify-content-center banner-container">
-    <span class="fr-pb-2v fr-px-3v fr-pt-1v banner banner--join">
+    <span class="fr-pb-2v fr-px-3v fr-pt-1v banner banner--join d-flex">
         Certains espaces sont réservés aux membres du projet. Pour y accéder,
-        <span class="text-underline cursor-pointer"
-              data-bs-toggle="dropdown"
-              data-bs-auto-close="outside"
-              aria-expanded="false"
-              aria-controls="select-observer-or-advisor">rejoignez le</span>.</span>
-    </div>
+        <form method="post" action="{% url 'projects-project-switchtender-join' project.id %}">
+            {% csrf_token %}
+            <button class="text-underline specific-hover-blue" x-on:click="$store.showRole.setShowToTrue">devenez conseiller</button>
+        </form>
+            ou
+        <form method="post" action="{% url 'projects-project-observer-join' project.id %}">
+            {% csrf_token %}
+            <button class="text-underline specific-hover-blue" x-on:click="$store.showRole.setShowToTrue">devenez observateur</button>
+        </form>
+    </span>
+</div>

--- a/recoco/apps/projects/templates/projects/project/fragments/project_banner/join_project_banner.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/project_banner/join_project_banner.html
@@ -4,17 +4,19 @@
           rel="stylesheet"
           type="text/css">
 {% endblock css %}
-<div class="d-flex justify-content-center banner-container">
-    <span class="fr-pb-2v fr-px-3v fr-pt-1v banner banner--join d-flex">
+<div class="d-flex justify-content-center banner-container banner banner--join fr-pb-2v fr-px-3v fr-pt-1v">
+    <span>
         Certains espaces sont réservés aux membres du projet. Pour y accéder,
-        <form method="post" action="{% url 'projects-project-switchtender-join' project.id %}">
-            {% csrf_token %}
-            <button class="text-underline specific-hover-blue" x-on:click="$store.showRole.setShowToTrue">devenez conseiller</button>
-        </form>
-            ou
-        <form method="post" action="{% url 'projects-project-observer-join' project.id %}">
-            {% csrf_token %}
-            <button class="text-underline specific-hover-blue" x-on:click="$store.showRole.setShowToTrue">devenez observateur</button>
-        </form>
     </span>
+    <form method="post" action="{% url 'projects-project-switchtender-join' project.id %}">
+        {% csrf_token %}
+        <button class="text-underline specific-hover-blue" x-on:click="$store.showRole.setShowToTrue">devenez conseiller</button>
+    </form>
+    <span>
+        ou
+    </span>
+    <form method="post" action="{% url 'projects-project-observer-join' project.id %}">
+        {% csrf_token %}
+        <button class="text-underline specific-hover-blue" x-on:click="$store.showRole.setShowToTrue">devenez observateur</button>
+    </form>
 </div>

--- a/recoco/apps/projects/templates/projects/project/knowledge.html
+++ b/recoco/apps/projects/templates/projects/project/knowledge.html
@@ -7,6 +7,9 @@
 {% block css %}
     {% vite_asset 'css/projectDetails.css' %}
 {% endblock css %}
+{% block js %}
+    {% vite_asset 'js/store/showRole.js' %}
+{% endblock js %}
 {% block title %}
     État des lieux - {{ block.super }}
 {% endblock title %}
@@ -61,7 +64,7 @@
         }
 	}
     </style>
-    <div class="col-12">
+    <div x-data x-init="$nextTick(() => $store.showRole.init())" class="col-12">
         {% include "projects/project/navigation.html" with state_of_play=True %}
         {% if project.inactive_since != None %}
             <div class="specific-border-4pxsolid1e1e1e">

--- a/recoco/apps/projects/templates/projects/project/knowledge.html
+++ b/recoco/apps/projects/templates/projects/project/knowledge.html
@@ -73,7 +73,7 @@
                     {% elif not advising and is_regional_actor and not is_staff %}
                         <div class="specific-border-4pxsolid000091">
                             {% include "projects/project/fragments/project_banner/join_project_banner.html" %}
-                            <div class="specific-opacity-02">
+                            <div>
                             {% endif %}
                             {% include "projects/project/fragments/survey_grid.html" %}
                             {% if project.inactive_since != None %}

--- a/recoco/apps/projects/templates/projects/project/navigation.html
+++ b/recoco/apps/projects/templates/projects/project/navigation.html
@@ -14,13 +14,18 @@
 {% block js %}
     {% vite_asset 'js/store/projectQueue.js' %}
     {% vite_asset 'js/components/ExpandableMenuHandler.js' %}
+    {% vite_asset 'js/store/showRole.js' %}
 {% endblock js %}
 {% get_obj_perms request.user for request.site as "user_site_perms" %}
 {% get_obj_perms request.user for project as "user_project_perms" %}
 {% is_staff_for_current_site request.user as is_staff %}
 {% get_advising_position user project request.site as position %}
-<div class="project-navigation d-flex justify-content-between">
-    <fieldset x-data
+<div x-data
+     class="project-navigation d-flex justify-content-between"
+     x-init="$nextTick(() => $store.showRole.init())"
+     >
+    <fieldset
+
               class="fr-segmented fr-segmented--md fr-px-3w"
               x-init="$nextTick(() => $store.projectQueue.addCurrentProjectId({{ project.id }}, `{{ project.name }}`, `{{ project.commune.name }}`,`{{ project.commune.insee }}`))">
         <legend class="fr-segmented__legend visually-hidden">Onglets du projet</legend>
@@ -197,6 +202,7 @@
                 <button class="fr-btn fr-btn--tertiary-no-outline fr-icon-team-line"
                         role="button"
                         x-ref="expandMenuButton"
+                        id="select-observer-or-advisor-button"
                         aria-expanded="false"
                         aria-controls="select-observer-or-advisor"
                         data-test-id="show-banner">Sélectionnez votre rôle sur le projet</button>

--- a/recoco/apps/projects/templates/projects/project/overview.html
+++ b/recoco/apps/projects/templates/projects/project/overview.html
@@ -76,7 +76,7 @@
                             {% include "projects/project/fragments/project_banner/join_project_banner.html" %}
                         {% endif %}
                         <div class="container-fluid">
-                            <div class="row fr-p-1w {% if project.inactive_since != None %}no-interaction-possible {% elif not advising and is_regional_actor and not is_staff %}specific-opacity-02{% endif %}">
+                            <div class="row fr-p-1w {% if project.inactive_since != None %}no-interaction-possible{% endif %}">
                                 <div class="col-8">
                                     <div class="d-flex">
                                         {% if "use_advisor_note" in user_project_perms %}

--- a/recoco/frontend/src/js/store/showRole.js
+++ b/recoco/frontend/src/js/store/showRole.js
@@ -1,0 +1,27 @@
+import Alpine from 'alpinejs';
+// import { document } from 'postcss';
+
+/**
+ * Alpine.js store for managing the showRole state.
+ *
+ * @store showRole
+ *
+ * @method init - Show the role if the showRole store exist (and is true).
+ * @method setShowToTrue - Sets the showRole store to true.
+ */
+
+Alpine.store('showRole', {
+  init() {
+    const showRole = localStorage.getItem('showRole');
+    if (showRole) {
+      document.getElementById('select-observer-or-advisor-button').click();
+      localStorage.removeItem('showRole');
+    }
+  },
+
+  setShowToTrue() {
+    localStorage.setItem('showRole', true);
+  },
+});
+
+export default Alpine.store('showRole');

--- a/recoco/frontend/src/js/store/showRole.js
+++ b/recoco/frontend/src/js/store/showRole.js
@@ -14,13 +14,17 @@ Alpine.store('showRole', {
   init() {
     const showRole = localStorage.getItem('showRole');
     if (showRole) {
+      //   alert("on devrait voir la modal s'ouvir");
       document.getElementById('select-observer-or-advisor-button').click();
       localStorage.removeItem('showRole');
+    } else {
+      //   alert("on devrait pas voir la modal s'ouvrir");
     }
   },
 
   setShowToTrue() {
     localStorage.setItem('showRole', true);
+    alert('coucou');
   },
 });
 

--- a/recoco/frontend/vite.config.js
+++ b/recoco/frontend/vite.config.js
@@ -61,8 +61,11 @@ const config = {
         tasksEmbed: resolve('./src/js/apps/tasksEmbed.js'),
         projectKnowledge: resolve('./src/js/apps/projectKnowledge.js'),
         selectSearchable: resolve('./src/js/apps/selectSearchable.js'),
-        ExpandableMenuHandler: resolve("./src/js/components/ExpandableMenuHandler.js"),
+        ExpandableMenuHandler: resolve(
+          './src/js/components/ExpandableMenuHandler.js'
+        ),
         projectQueue: resolve('./src/js/store/projectQueue.js'),
+        showRole: resolve('./src/js/store/showRole.js'),
       },
       output: {
         chunkFileNames: undefined,


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Changement de la couleur de la bannière lorsque l'on est pas observateur.trice ou conseiller.e d'un projet.
Ajout de lien pour devenir observateur.trice ou conseiller.e
Ouverture de la fenêtre modale de sélection de rôle une fois un rôle choisi avec les boutons indiqués au dessus.
Suppression de la transparence sur le contenu.

![image](https://github.com/user-attachments/assets/714556aa-36df-4bc1-9ba8-0de23eaa80c9)

Close #748 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
