### PR TITLE
[fix] change recommandation emission visibility for staff and join pr…

### DIFF
--- a/recoco/apps/projects/templates/projects/project/actions.html
+++ b/recoco/apps/projects/templates/projects/project/actions.html
@@ -52,7 +52,7 @@
                                 <p class="fst-italic fw-light fr-mb-2w">
                                     Soyez la première personne à proposer des recommandations ou des ressources à la collectivité !
                                 </p>
-                                {% if advising %}
+                                {% if advising or is_staff %}
                                     <a data-test-id="submit-task-button"
                                        href="{% url 'projects-create-task' %}?project_id={{ project.id }}"
                                        class="fr-btn">Émettre une recommandation</a>
@@ -62,8 +62,13 @@
                                         <span class="badge bg-warning">Beta feature</span> <a href="{% url 'projects-project-tasks-suggest' project.pk %}">Examiner les recommandation suggérées automatiquement pour ce projet</a>
                                     </p>
                                 {% else %}
-                                    <a href="{% url 'projects-project-switchtender-join' project.id %}"
-                                       class="fr-btn">Rejoindre ce projet pour l'aiguiller</a>
+                                    <button class="fr-btn"
+                                            data-bs-toggle="dropdown"
+                                            data-bs-auto-close="outside"
+                                            aria-expanded="false"
+                                            aria-controls="select-observer-or-advisor">
+                                        Rejoindre ce projet pour l'aiguiller
+                                    </button>
                                 {% endif %}
                             </div>
                         {% elif not is_switchtender and project.tasks.public.count == 0 %}

--- a/recoco/apps/projects/templates/projects/project/navigation.html
+++ b/recoco/apps/projects/templates/projects/project/navigation.html
@@ -281,10 +281,7 @@
                                         <form method="post"
                                               action="{% url 'projects-project-access-advisor-delete' project.pk request.user.username %}">
                                             {% csrf_token %}
-                                            <button class="fr-btn fr-btn--sm fr-btn--tertiary w-100 justify-content-center"
-                                                    {% comment %}
-                                                    x-on:click="role={% url 'projects-project-access-advisor-delete' project.pk request.user.username %}"
-                                                    {% endcomment %}>Quitter le projet</button>
+                                            <button class="fr-btn fr-btn--sm fr-btn--tertiary w-100 justify-content-center">Quitter le projet</button>
                                         </form>
                                     </div>
                                 </div>


### PR DESCRIPTION
…oject button effect #762

Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Changement du comportement du bouton "rejoindre ce projet pour l'aiguiller" pour ouvrir le menu déroulant permettant de choisir un rôle.

![image](https://github.com/user-attachments/assets/b3351dbb-d56a-4c19-8106-f2f41123ec14)

Changement de l'affichage de la page d'émission de recommandation pour afficher directement la possibilité au membre de staff d'émettre des recommandations sur un projet sans avoir besoin de devenir observateur.rice ou conseiller.e.

Close #762 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
