### PR TITLE
[style] Affichage de l'entête du tableau de bord sur petit écrans

### DIFF
--- a/recoco/apps/projects/static/projects/css/kanban.scss
+++ b/recoco/apps/projects/static/projects/css/kanban.scss
@@ -1,8 +1,22 @@
 .kanban {
+  &-header {
+    &__middle-part {
+      display: flex;
+      flex-grow: 1;
+    }
+    &__searchbar {
+      flex-grow: 1;
+      margin: 0;
+      margin-right: 1.5rem;
+    }
+    &__my-projects-toggle {
+      margin-right: 1.5rem;
+      padding-top: 6px;
+    }
+  }
   &-container {
     overflow-x: auto;
     overflow-y: hidden;
-    // height: 85vh;
   }
 
   &-column-container {
@@ -136,4 +150,40 @@ h5 {
 .not-a-link {
   text-decoration: none;
   color: #666666;
+}
+
+@media screen and (max-width: 1420px) {
+  .kanban {
+    &-header {
+      flex-wrap: wrap;
+      &__view-selector {
+        order: 1;
+        flex-grow: 1;
+        justify-content: start;
+      }
+      &__view-selector {
+        order: 1;
+      }
+      &__middle-part {
+        order: 3;
+        width: 100%;
+        margin-top: 0.626rem;
+      }
+      &__searchbar {
+        flex-grow: 1;
+        margin-left: 0;
+        order: 1;
+      }
+      &__toolbar {
+        order: 2;
+      }
+      &__my-projects-toggle {
+        order: 3;
+        margin-right: 0;
+      }
+      &__region-filter {
+        order: 2;
+      }
+    }
+  }
 }

--- a/recoco/apps/projects/templates/projects/project/fragments/list-toolbars.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/list-toolbars.html
@@ -1,9 +1,9 @@
 {% load static %}
-<div class="btn-group fr-ml-3w" role="group" aria-label="Admin actions">
-    <a class="fr-btn fr-btn--sm fr-mr-1v"
+<div class="btn-group" role="group" aria-label="Admin actions">
+    <a class="fr-btn fr-btn--sm fr-mr-1v text-nowrap"
        href="{% url 'onboarding-prefill-set-user' %}"
        role="button">Déposer un projet</a>
-    <a class="fr-btn fr-btn--sm fr-btn--secondary fr-mr-1v"
+    <a class="fr-btn fr-btn--sm fr-btn--secondary fr-mr-1v text-nowrap"
        href="{% url 'projects-project-list-export-csv' %}"
        role="button">Exporter en CSV</a>
 </div>

--- a/recoco/apps/projects/templates/projects/project/fragments/personal_dashboard/personal_dashboard_header.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/personal_dashboard/personal_dashboard_header.html
@@ -8,9 +8,9 @@
 </div>
 <header class="d-flex justify-content-between fr-p-2v ">
     <span class="fs-5">{% include "projects/project/fragments/navigation/display_select.html" %}</span>
-    <div class="fr-ml-3w flex-grow-1">
+    <div class="fr-ml-3w flex-grow-1 fr-mr-6v">
         {% include "projects/project/fragments/search_bar.html" with action_search="handleProjectsSearch" x_model="search" %}
     </div>
-    {% include "projects/project/fragments/region_filter.html"  with filter_by_regions=False %}
+    {% include "projects/project/fragments/region_filter.html" with filter_by_regions=False %}
     {% include "projects/project/fragments/list-toolbars.html" %}
 </header>

--- a/recoco/apps/projects/templates/projects/project/fragments/region_filter.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/region_filter.html
@@ -5,7 +5,7 @@
           rel="stylesheet"
           type="text/css">
 {% endblock css %}
-<div class="d-flex align-items-center fr-ml-3w">
+<div class="d-flex align-items-center fr-mr-6v">
     <span class="fr-segmented__legend inline text-nowrap">Filtrer :</span>
     <div class="input-item position-relative active specific-border-solid1pxE5E5E5"
          x-data="{ open: false }"

--- a/recoco/apps/projects/templates/projects/project/list-kanban.html
+++ b/recoco/apps/projects/templates/projects/project/list-kanban.html
@@ -34,14 +34,23 @@
                 <span class="visually-hidden">Loading...</span>
             </div>
         </div>
-        <div class="topbar d-flex justify-content-between align-items-center fr-p-2v ">
-            <span class="fs-5">{% include "projects/project/fragments/navigation/display_select.html" %}</span>
-            <div class="fr-mx-3w flex-grow-1">
-                {% include "projects/project/fragments/search_bar.html" with action_search="onSearch(event)" x_model="searchText" %}
+        <div class="kanban-header topbar d-flex justify-content-between align-items-center fr-p-2v">
+            <div class="kanban-header__view-selector fs-5 fr-mr-6v">
+                {% include "projects/project/fragments/navigation/display_select.html" %}
             </div>
-            {% include "projects/project/fragments/only_my_projects_toggle.html" %}
-            {% include "projects/project/fragments/region_filter.html" with filter_by_regions=True %}
-            {% include "projects/project/fragments/list-toolbars.html" %}
+            <div class="kanban-header__middle-part">
+                {% comment %} <div class="kanban-header__searchbar fr-mx-3w flex-grow-1"> {% endcomment %}
+                <div class="kanban-header__searchbar">
+                    {% include "projects/project/fragments/search_bar.html" with action_search="onSearch(event)" x_model="searchText" %}
+                </div>
+                <div class="kanban-header__my-projects-toggle">
+                    {% include "projects/project/fragments/only_my_projects_toggle.html" %}
+                </div>
+                <div class="kanban-header__region-filter">
+                    {% include "projects/project/fragments/region_filter.html" with filter_by_regions=True %}
+                </div>
+            </div>
+            <div class="kanban-header__toolbar">{% include "projects/project/fragments/list-toolbars.html" %}</div>
         </div>
         <div x-init="getData()" x-cloak class="d-flex">
             <div class="flex-grow-1 kanban-container">


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Ajout du responsive pour les petits écrans 


**Écrans larges :**
<img width="1512" alt="Capture d’écran 2024-11-12 à 12 07 39" src="https://github.com/user-attachments/assets/5f4428b5-26cb-4b87-a760-794735e2e5dc">

---

**Écrans moins large :**
<img width="1372" alt="Capture d’écran 2024-11-12 à 12 08 37" src="https://github.com/user-attachments/assets/7f41dadd-1ad8-451f-9893-9958879941ff">

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
