### PR TITLE
[fix] hide create project button for people that aren't staff or obse…

### DIFF
--- a/recoco/apps/projects/templates/projects/project/fragments/list-toolbars.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/list-toolbars.html
@@ -1,6 +1,6 @@
 {% load static %}
 <div class="btn-group" role="group" aria-label="Admin actions">
-   {% if advising or is_regional_actor or is_staff or is_switchtender %}
+   {% if is_switchtender %}
     <a class="fr-btn fr-btn--sm fr-mr-1v text-nowrap"
        href="{% url 'onboarding-prefill-set-user' %}"
        role="button">Déposer un projet</a>

--- a/recoco/apps/projects/templates/projects/project/fragments/list-toolbars.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/list-toolbars.html
@@ -1,8 +1,10 @@
 {% load static %}
 <div class="btn-group" role="group" aria-label="Admin actions">
+   {% if advising or is_regional_actor or is_staff or is_switchtender %}
     <a class="fr-btn fr-btn--sm fr-mr-1v text-nowrap"
        href="{% url 'onboarding-prefill-set-user' %}"
        role="button">Déposer un projet</a>
+   {% endif %}
     <a class="fr-btn fr-btn--sm fr-btn--secondary fr-mr-1v text-nowrap"
        href="{% url 'projects-project-list-export-csv' %}"
        role="button">Exporter en CSV</a>


### PR DESCRIPTION
…rver or advisor

Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Ajout d'une condition à l'affichage du bouton "Déposer un projet" pour qu'il ne s'affiche que pour les administrateur.trices, les conseiller.es ou les observateur.trices.

Avant :
![image](https://github.com/user-attachments/assets/882400f8-9355-45b6-bd7d-3ca1583c4068)


Après : 
![image](https://github.com/user-attachments/assets/72deb4f6-7dc3-4e1e-8306-5d20b22c0dd2)


## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
