### PR TITLE
[fix] Disable some ruff rules in settings modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ section-order = [
 [tool.ruff.lint.extend-per-file-ignores]
 "**/migrations/*.py" = ["I"]
 "**/test_*.py" = ["S105"]
+"recoco/settings/*.py" = ["F403", "F405"]
 
 [tool.ruff.lint.flake8-bandit]
 check-typed-exception = true

--- a/recoco/settings/frontend_tests.py.example
+++ b/recoco/settings/frontend_tests.py.example
@@ -21,7 +21,7 @@ DJANGO_DEBUG = True
 
 ALLOWED_HOSTS = ["example.localhost"]
 
-INSTALLED_APPS += (  # noqa: F405
+INSTALLED_APPS += (
     "drf_spectacular",
     "drf_spectacular_sidecar",
     "django_extensions",
@@ -67,7 +67,7 @@ BREVO_FORCE_DEBUG = True
 RECAPTCHA_REQUIRED_SCORE = 0
 
 # Vite
-DJANGO_VITE_ASSETS_PATH = BASE_DIR / "frontend" / "dist"  # noqa: F405
+DJANGO_VITE_ASSETS_PATH = BASE_DIR / "frontend" / "dist"
 DJANGO_VITE = {
     "default": {
         "dev_mode": False,
@@ -76,10 +76,10 @@ DJANGO_VITE = {
     }
 }
 
-MULTISITE_REPO_DIR = BASE_DIR / ".." / "multisites"  # noqa: F405
-TEMPLATES[0]["DIRS"] += [MULTISITE_REPO_DIR / "templates"]  # noqa: F405
-STATICFILES_DIRS += [MULTISITE_REPO_DIR / "static"]  # noqa: F405
-STATICFILES_DIRS += [BASE_DIR / "static"]  # noqa: F405
+MULTISITE_REPO_DIR = BASE_DIR / ".." / "multisites"
+TEMPLATES[0]["DIRS"] += [MULTISITE_REPO_DIR / "templates"]
+STATICFILES_DIRS += [MULTISITE_REPO_DIR / "static"]
+STATICFILES_DIRS += [BASE_DIR / "static"]
 STATICFILES_DIRS += [DJANGO_VITE_ASSETS_PATH]
 
 
@@ -87,7 +87,7 @@ STATICFILES_DIRS += [DJANGO_VITE_ASSETS_PATH]
 # GDAL_LIBRARY_PATH = "/opt//homebrew/lib/libgdal.dylib"
 # GEOS_LIBRARY_PATH = "/opt//homebrew/lib/libgeos_c.dylib"
 
-SILENCED_SYSTEM_CHECKS += ["captcha.recaptcha_test_key_error"]  # noqa: F405
+SILENCED_SYSTEM_CHECKS += ["captcha.recaptcha_test_key_error"]
 
 # Celery
 CELERY_TASK_ALWAYS_EAGER = True

--- a/recoco/settings/frontend_tests_permissions.py.example
+++ b/recoco/settings/frontend_tests_permissions.py.example
@@ -11,7 +11,7 @@ import os
 
 from dotenv import load_dotenv
 
-from .common import *  # noqa: F403
+from .common import *
 
 load_dotenv()
 
@@ -21,7 +21,7 @@ DJANGO_DEBUG = True
 
 ALLOWED_HOSTS = ["example.localhost"]
 
-INSTALLED_APPS += (  # noqa: F405
+INSTALLED_APPS += (
     "drf_spectacular",
     "drf_spectacular_sidecar",
     "django_extensions",
@@ -53,7 +53,7 @@ BREVO_FORCE_DEBUG = True
 RECAPTCHA_REQUIRED_SCORE = 0
 
 # Vite
-DJANGO_VITE_ASSETS_PATH = BASE_DIR / "frontend" / "dist"  # noqa: F405
+DJANGO_VITE_ASSETS_PATH = BASE_DIR / "frontend" / "dist"
 DJANGO_VITE = {
     "default": {
         "dev_mode": DEBUG,
@@ -63,10 +63,10 @@ DJANGO_VITE = {
 DJANGO_VITE_DEV_MODE = DEBUG
 
 
-MULTISITE_REPO_DIR = BASE_DIR / ".." / "multisites"  # noqa: F405
-TEMPLATES[0]["DIRS"] += [MULTISITE_REPO_DIR / "templates"]  # noqa: F405
-STATICFILES_DIRS += [MULTISITE_REPO_DIR / "static"]  # noqa: F405
-STATICFILES_DIRS += [BASE_DIR / "static"]  # noqa: F405
+MULTISITE_REPO_DIR = BASE_DIR / ".." / "multisites"
+TEMPLATES[0]["DIRS"] += [MULTISITE_REPO_DIR / "templates"]
+STATICFILES_DIRS += [MULTISITE_REPO_DIR / "static"]
+STATICFILES_DIRS += [BASE_DIR / "static"]
 STATICFILES_DIRS += [DJANGO_VITE_ASSETS_PATH]
 
 
@@ -74,7 +74,7 @@ STATICFILES_DIRS += [DJANGO_VITE_ASSETS_PATH]
 # GDAL_LIBRARY_PATH = "/opt//homebrew/lib/libgdal.dylib"
 # GEOS_LIBRARY_PATH = "/opt//homebrew/lib/libgeos_c.dylib"
 
-SILENCED_SYSTEM_CHECKS += ["captcha.recaptcha_test_key_error"]  # noqa: F405
+SILENCED_SYSTEM_CHECKS += ["captcha.recaptcha_test_key_error"]
 
 # Celery
 CELERY_TASK_ALWAYS_EAGER = True


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

Désactivation des rules ruff F403 et F405 dans les modules python de settings.
Compte-tenu de l'utilisation en mode "surcharge", ces règles ne sont pas pertinentes et n'apportent pas de quelité de code supplémentaire sur cette partie du code.

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
