### PR TITLE
[fix] change save button display for drafted task #797

### DIFF
--- a/recoco/templates/default_site/tools/editor.html
+++ b/recoco/templates/default_site/tools/editor.html
@@ -55,12 +55,22 @@
              @click.stop
              id="comment-text-ref"></div>
         {% if is_task_comment %}
-            <div class="d-flex justify-content-end">
-                <button class="fr-btn fr-btn--sm"
-                        :disabled="$store.editor.isSubmitted === true"
-                        @click.stop="handleEditComment(markdownContent,task)"
-                        data-test-id="button-submit-edit">Enregistrer</button>
-            </div>
+            <template x-if="task.public == false">
+                <div class="d-flex justify-content-end">
+                    <button class="fr-btn fr-btn--sm"
+                            :disabled="$store.editor.isSubmitted === true"
+                            @click.stop="handleEditComment(markdownContent,task)"
+                            data-test-id="button-submit-edit">Enregistrer en brouillon</button>
+                </div>
+            </template>
+            <template x-if="task.public == true">
+                <div class="d-flex justify-content-end">
+                    <button class="fr-btn fr-btn--sm"
+                            :disabled="$store.editor.isSubmitted === true"
+                            @click.stop="handleEditComment(markdownContent,task)"
+                            data-test-id="button-submit-edit">Enregistrer</button>
+                </div>
+            </template>
         {% endif %}
         {% if is_task_modal_comment %}
             <div class="d-flex justify-content-end">


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Changement de l'affichage du bouton enregistrer pour modifier un commentaire sur une ressource.

Il affiche maintenant "Enregistrer en brouillon" pour les ressources en brouillon :
![image](https://github.com/user-attachments/assets/1f45f1e8-64fb-4d8d-90a6-6854be37d7ca)

Resolved #797 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
