### PR TITLE
[fix] hide citation section if it's content is empty

### DIFF
--- a/recoco/apps/pages/templates/pages/showcase_page.html
+++ b/recoco/apps/pages/templates/pages/showcase_page.html
@@ -79,12 +79,12 @@
             </div>
         </div>
         <!--------------------- page.quote ------------------------>
-        <div class="fr-py-3w fr-my-1w">
-            <div class="fr-container">
-                <div class="fr-grid-row fr-grid-row--gutters fr-py-1w">
-                    <div class="fr-col-12 fr-col-sm">
-                        <figure class="fr-quote fr-quote--column">
-                            {% for block in page.quote %}
+        {% for block in page.quote %}
+            <div class="fr-py-3w fr-my-1w">
+                <div class="fr-container">
+                    <div class="fr-grid-row fr-grid-row--gutters fr-py-1w">
+                        <div class="fr-col-12 fr-col-sm">
+                            <figure class="fr-quote fr-quote--column">
                                 <blockquote>
                                     <p>{{ block.value.quote }}</p>
                                 </blockquote>
@@ -93,11 +93,11 @@
                                     <p class="fr-quote__source">{{ block.value.author_title }}</p>
                                     <div class="fr-quote__image">{% image block.value.image width-400 class='left_image' %}</div>
                                 </figcaption>
-                            {% endfor %}
-                        </figure>
+                            </figure>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
+        {% endfor %}
     </div>
 {% endblock content %}


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Modification du rendu de la page cas d'usage pour ne plus afficher le cadre de la section citation si cette dernière n'est pas remplie.

Avant : 
<img width="1333" alt="image" src="https://github.com/user-attachments/assets/4f3fed8c-70eb-4e56-92e3-96e3ecd3499d" />


Après :

<img width="1227" alt="image" src="https://github.com/user-attachments/assets/b24cf13d-989f-4e6b-8047-878a639d89e7" />


## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
