### PR TITLE
[feat] Cacher les CTA sur l'EDL pour les Staff et Conseillers

### DIFF
--- a/frontend_tests/cypress/e2e/project/survey/canSeeCtaOnSurvey.cy.js
+++ b/frontend_tests/cypress/e2e/project/survey/canSeeCtaOnSurvey.cy.js
@@ -1,0 +1,19 @@
+describe('I can see CTA on survey page', () => {
+  it('should display CTA as collectivity', () => {
+    cy.login('collectivité1');
+    cy.visit(`/project/2/connaissance`);
+    cy.get('[data-test-id="link-fill-survey-cta"]').should('be.visible');
+  });
+
+  it('should not display CTA as staff', () => {
+    cy.login('staff');
+    cy.visit(`/project/2/connaissance`);
+    cy.get('[data-test-id="link-fill-survey-cta"]').should('not.exist');
+  });
+
+  it('should not display CTA as staff', () => {
+    cy.login('conseiller1');
+    cy.visit(`/project/2/connaissance`);
+    cy.get('[data-test-id="link-fill-survey-cta"]').should('not.exist');
+  });
+});

--- a/recoco/apps/projects/templates/projects/project/fragments/survey_grid.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/survey_grid.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load sass_tags %}
 {% load django_vite %}
+{% load projects_extra %}
 {% block css %}
     <link href="{% sass_src 'projects/css/fragments/survey_grid.scss' %}"
           rel="stylesheet"
@@ -65,39 +66,59 @@
                 projet envoyé par {{ project.project_sites.origin.site.name }}
             </div>
         </div>
+        {% get_advising_position user project request.site as position %}
         <div class="col-9 knowledge__surveys">
-            <div class="d-flex justify-content-between knowledge__surveys-header fr-mt-5v">
-                <h3 class="fr-m-0">État des lieux</h3>
-                {% comment %} TODO
+            {% if not is_staff and not position.is_advisor and not position.is_observer %}
+                <div class="d-flex justify-content-between knowledge__surveys-header fr-mt-5v">
+                    <h3 class="fr-m-0">État des lieux</h3>
+                    {% comment %} TODO
                 - refonte modal share EDL
-                {% endcomment %}
+                    {% endcomment %}
+                    {% if "use_surveys" in user_project_perms %}
+                        <div x-data="ProjectShare" class="d-flex align-items-center">
+                            <button @click="openPublicShareModal"
+                                    data-toggle="modal"
+                                    data-target="#publicShareModal"
+                                    data-test-id="public-share-button"
+                                    {% if project.status == 'DRAFT' %}disabled{% endif %}
+                                    class="fr-btn fr-btn--sm fr-btn--secondary {% if project.status == 'DRAFT' %}fr-btn--icon-left fr-icon-lock-line disabled{% endif %}">
+                                Partager l'état des lieux
+                            </button>
+                            {% include "projects/project/fragments/share/public_share_modal.html" %}
+                        </div>
+                    {% endif %}
+                </div>
                 {% if "use_surveys" in user_project_perms %}
-                    <div x-data="ProjectShare" class="d-flex align-items-center">
-                        <button @click="openPublicShareModal"
-                                data-toggle="modal"
-                                data-target="#publicShareModal"
-                                data-test-id="public-share-button"
-                                {% if project.status == 'DRAFT' %}disabled{% endif %}
-                                class="fr-btn fr-btn--sm fr-btn--secondary {% if project.status == 'DRAFT' %}fr-btn--icon-left fr-icon-lock-line disabled{% endif %}">
-                            Partager l'état des lieux
-                        </button>
-                        {% include "projects/project/fragments/share/public_share_modal.html" %}
-                    </div>
+                    {% for session in sorted_sessions %}
+                        <div class="survey-card-cta">
+                            <div class="survey-card-cta__title" data-cy="survey-name">{{ session.survey.name }}</div>
+                            <a class="fr-btn fr-btn--sm"
+                               data-test-id="link-fill-survey"
+                               href="{% url 'survey-project-session' project_id=project.pk site_id=session.survey.site.id %}">Compléter le questionnaire</a>
+                        </div>
+                    {% endfor %}
                 {% endif %}
-            </div>
-            {% if "use_surveys" in user_project_perms %}
-                {% for session in sorted_sessions %}
-                    <div class="survey-card-cta">
-                        <div class="survey-card-cta__title" data-cy="survey-name">{{ session.survey.name }}</div>
-                        <a class="fr-btn fr-btn--sm"
-                           data-test-id="link-fill-survey"
-                           href="{% url 'survey-project-session' project_id=project.pk site_id=session.survey.site.id %}">Compléter le questionnaire</a>
-                    </div>
-                {% endfor %}
             {% endif %}
             <div class="fr-mt-3w">
                 {% for session in sorted_sessions %}
-                    <h4>{{ session.survey.name }}</h4>
+                    <div class="d-flex justify-content-between knowledge__surveys-header fr-mt-5v">
+                        <h4 class="fr-m-0">{{ session.survey.name }}</h4>
+                        {% if is_staff or position.is_advisor or position.is_observer %}
+                            {% if "use_surveys" in user_project_perms %}
+                                <div x-data="ProjectShare" class="d-flex align-items-center">
+                                    <button @click="openPublicShareModal"
+                                            data-toggle="modal"
+                                            data-target="#publicShareModal"
+                                            data-test-id="public-share-button"
+                                            {% if project.status == 'DRAFT' %}disabled{% endif %}
+                                            class="fr-btn fr-btn--sm fr-btn--secondary {% if project.status == 'DRAFT' %}fr-btn--icon-left fr-icon-lock-line disabled{% endif %}">
+                                        Partager l'état des lieux
+                                    </button>
+                                    {% include "projects/project/fragments/share/public_share_modal.html" %}
+                                </div>
+                            {% endif %}
+                        {% endif %}
+                    </div>
                     <div class="masonry-wrapper row"
                          data-masonry='{"percentPosition": true, "transitionDuration": 0 }'>
                         <!-- Show QS with progress -->

--- a/recoco/apps/projects/templates/projects/project/fragments/survey_grid.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/survey_grid.html
@@ -93,7 +93,7 @@
                         <div class="survey-card-cta">
                             <div class="survey-card-cta__title" data-cy="survey-name">{{ session.survey.name }}</div>
                             <a class="fr-btn fr-btn--sm"
-                               data-test-id="link-fill-survey"
+                               data-test-id="link-fill-survey-cta"
                                href="{% url 'survey-project-session' project_id=project.pk site_id=session.survey.site.id %}">Compléter le questionnaire</a>
                         </div>
                     {% endfor %}


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

Pour les staff et conseillers : 
<img width="1510" alt="Capture d’écran 2025-01-08 à 18 30 26" src="https://github.com/user-attachments/assets/be53b13a-666e-469f-9d51-0c6131ca43ad" />

Pour les collectivités : 
<img width="1512" alt="Capture d’écran 2025-01-08 à 18 30 56" src="https://github.com/user-attachments/assets/cfec983e-f26a-480a-9c9c-6bd1ec43e065" />

#887 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x]  L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
