### PR TITLE
[fix] Add a trick to skip metrics tests that create roles

### DIFF
--- a/recoco/apps/metrics/tests/test_command.py
+++ b/recoco/apps/metrics/tests/test_command.py
@@ -1,3 +1,4 @@
+import os
 import random
 import string
 from io import StringIO
@@ -55,6 +56,17 @@ class TestCommand(BaseClassTestMixin):
                 f"SELECT COUNT(*) FROM pg_roles WHERE rolname='metrics_{random_prefix}_owner_example_com';"
             )
             assert cursor.fetchone()[0] == 0
+
+    @pytest.mark.skipif(
+        os.environ.get("SKIP_TEST_METRICS_CREATE_ROLES") == "true",
+        reason="Skipping metrics tests that create roles",
+    )
+    @pytest.mark.django_db(transaction=True)
+    def test_full_command_create_roles(self, settings):
+        random_prefix = "".join(
+            random.choices(string.ascii_lowercase, k=10)  # noqa: S311
+        )
+        settings.METRICS_PREFIX = f"metrics_{random_prefix}"
 
         call_command("update_materialized_views", create_roles=True)
 


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

Pour l'activer, ajouter cette ligne dans `development.py`, juste avant `load_dotenv`:
```python
os.environ.setdefault("SKIP_TEST_METRICS_CREATE_ROLES", "true")
load_dotenv()
...
```

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
