### PR TITLE
[fix] add dsfr blue to custom banner

### DIFF
--- a/recoco/apps/home/static/home/css/home/home.scss
+++ b/recoco/apps/home/static/home/css/home/home.scss
@@ -80,7 +80,7 @@ span.step {
 }
 
 .custom-banner {
-  background-color: #3558a2;
+  background-color: var(--background-action-high-blue-france);;
   color: white;
   position: absolute;
   right: -10px;


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Modification du bleu de la classe "custom-banner" pour la mettre à la teinte du dsfr.

Exemple de la classe : 
<img width="967" alt="image" src="https://github.com/user-attachments/assets/4e9fa922-8097-4662-9c72-27ef6ce41871" />


## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
