### PR TITLE
[fix] Ouverture de la modal de reco si son id est passé dans l'url

### DIFF
--- a/recoco/frontend/src/js/store/previewModal.js
+++ b/recoco/frontend/src/js/store/previewModal.js
@@ -61,12 +61,21 @@ document.addEventListener('alpine:init', () => {
       if (urlFromHash) {
         this.taskId = parseInt(urlFromHash[1], 10);
         if (this.newTasks.length === 0) {
-          await Alpine.store('tasksData').loadTasks();
+          const tasks = await Alpine.store('tasksData').loadTasks();
+          this.open(
+            tasks
+              .filter((task) => task.public)
+              .find((task) => task.id === this.taskId)
+          );
+        } else {
+          this.open(this.newTasks.find((task) => task.id === this.taskId));
         }
-        this.open(this.newTasks.find((task) => task.id === this.taskId));
       }
     },
     open(task) {
+      if (!task) {
+        throw new Error('Error while open task modal - task not found');
+      }
       this.isPaginated = false;
       this.setLocation(task.id);
       this.visitTask(task);


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Un problème survenait lors du clic sur une notif ou lors d'un partage d'url type https://urbanvitaliz.fr/project/2345/actions#action-5137
 
## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
