### PR TITLE
[feat] update accessibility page and correct link in li style

### DIFF
--- a/recoco/apps/home/static/home/css/home/home.scss
+++ b/recoco/apps/home/static/home/css/home/home.scss
@@ -144,3 +144,8 @@ span.step {
 .specific-maxwidth-160 {
   max-width: 160px;
 }
+
+.correct-link-display {
+  color: #0000ee;
+  text-decoration: underline;
+}

--- a/recoco/apps/home/templates/home/accessibility.html
+++ b/recoco/apps/home/templates/home/accessibility.html
@@ -22,7 +22,7 @@
             {{ request.site.name }} est une plateforme supportée par le logiciel Recommandations-collaboratives.
             Le Cerema porte Recommandations-collaboratives, qui permet aux administrations françaises de créer
             des plateformes thématiques de conseil aux porteurs de projet, sur un même modèle d’application web.
-            D’un point de vue technique, l’application Mon Espace Collectivité est gérée par l’équipe de Recommandations-collaboratives,
+            D’un point de vue technique, l’application {{ request.site.name }} est gérée par l’équipe de Recommandations-collaboratives,
             notamment en ce qui concerne l’accessibilité.
             Le Cerema s’engage à rendre son service accessible, conformément à l’article 47 de la loi n° 2005-102 du 11 février 2005.
             À cette fin, nous mettons en œuvre la stratégie et les actions suivantes : <a href="{% url 'multi-annual-schema' %}">schéma pluri-annuel 2024-2026</a>.
@@ -133,7 +133,7 @@
             Le Schéma Pluri-Annuel 2024-2026 cité plus haut donne plus de détails à ce sujet.
         </p>
         <p>
-            Si dans l’attente de cette refonte ou après, vous rencontrez des blocages pour utiliser le site, vous pouvez nous contacter à <a href="mailto:{{ sender_email }}">{{ sender_email }}</a>
+            Si dans l’attente de cette refonte ou après, vous rencontrez des blocages pour utiliser le site, vous pouvez nous contacter à <a href="mailto:{{ request.site.configuration.contact_form_recipient }}">{{ request.site.configuration.contact_form_recipient }}</a>
         </p>
         <h2>Établissement de cette déclaration d’accessibilité</h2>
         <p>Cette déclaration a été établie le 23 janvier 2025.</p>
@@ -163,7 +163,8 @@
         </p>
         <ul>
             <li>
-                E-mail : <a class="correct-link-display" href="mailto:{{ sender_email }}">{{ sender_email }}</a>
+                E-mail : <a class="correct-link-display"
+    href="mailto:{{ request.site.configuration.contact_form_recipient }}">{{ request.site.configuration.contact_form_recipient }}</a>
             </li>
         </ul>
         <br />

--- a/recoco/apps/home/templates/home/accessibility.html
+++ b/recoco/apps/home/templates/home/accessibility.html
@@ -14,15 +14,17 @@
 {% endblock css %}
 {% block content %}
     <div class="col-8 fr-py-2w g-0 fr-mx-auto">
-        <h1>Déclaration d’accessibilité</h1>
+        <h1>Déclaration d’accessibilité de {{ request.site.name }}</h1>
         <p>
-            <i>Établie le 2 février 2024.</i>
+            <i>Établie le 23 janvier 2025.</i>
         </p>
         <p>
-            Le Cerema porte le service Recommandations-Collaboratives, qui permet de créer des plateformes thématiques de conseil aux porteurs de projet, sur un même modèle d’application web. {{ request.site.name }} est l’une de ces plateformes. D’un point de vue technique, l’application {{ request.site.name }} est gérée par l’équipe de Recommandations-Collaboratives, notamment en ce qui concerne l’accessibilité.
-            <br />
+            {{ request.site.name }} est une plateforme supportée par le logiciel Recommandations-collaboratives.
+            Le Cerema porte Recommandations-collaboratives, qui permet aux administrations françaises de créer
+            des plateformes thématiques de conseil aux porteurs de projet, sur un même modèle d’application web.
+            D’un point de vue technique, l’application Mon Espace Collectivité est gérée par l’équipe de Recommandations-collaboratives,
+            notamment en ce qui concerne l’accessibilité.
             Le Cerema s’engage à rendre son service accessible, conformément à l’article 47 de la loi n° 2005-102 du 11 février 2005.
-            <br />
             À cette fin, nous mettons en œuvre la stratégie et les actions suivantes : <a href="{% url 'multi-annual-schema' %}">schéma pluri-annuel 2024-2026</a>.
             <br />
             Cette déclaration d’accessibilité s’applique à {{ request.site.name }} (<a href="https://{{ request.site }}/">https://{{ request.site }}</a>).
@@ -39,22 +41,8 @@
             <li>
                 <span class="fw-bold">D’une manière générale, sur la plupart des pages :</span>
                 <ul>
-                    <li>les contrastes sont insuffisants,</li>
                     <li>il manque le bouton Accéder au contenu,</li>
                     <li>la hiérarchie des titres n’est pas respectée.</li>
-                </ul>
-            </li>
-            <li>
-                <span class="fw-bold">Questionnaire d'état des lieux après dépôt d'un projet :</span>
-                <ul>
-                    <li>Navigation au clavier impossible,</li>
-                    <li>cas d’erreurs mal signalés.</li>
-                </ul>
-            </li>
-            <li>
-                <span class="fw-bold">Navigation au sein de l'application (menus) :</span>
-                <ul>
-                    <li>Navigationau clavier impossible</li>
                 </ul>
             </li>
             <li>
@@ -126,27 +114,29 @@
                 </ul>
             </li>
             <li>
-                <span class="fw-bold">Tableau de bord “staff” :</span>
+                <span class="fw-bold">Tableau de bord “staff” (vue tableau) :</span>
                 <ul>
-                    <li>au clavier, impossible de parcourir les projets</li>
+                    <li>au clavier, focus manquant sur les cartes des projets</li>
                 </ul>
             </li>
             <li>
-                <span class="fw-bold">Tableau de bord “conseiller” :</span>
+                <span class="fw-bold">Tableau de bord “conseiller” (vue liste) :</span>
                 <ul>
-                    <li>au clavier, impossible de parcourir les projets,</li>
                     <li>alternative à la carte manquante.</li>
                 </ul>
             </li>
         </ol>
         <p>
-            Afin de corriger ces problèmes, nous travaillons en 2024 à une refonte de la plupart des pages de l’application. Nous allons également nous appuyer de plus en plus sur des composants optimisés et réutilisés à travers le site, qui prennent bien en compte les critères d’accessibilité. Enfin, nous allons déployer plus largement le Système de Design de l’Etat (DSFR). Le Schéma Pluri-Annuel 2024-2026 cité plus haut donne plus de détails à ce sujet.
+            Afin de corriger ces problèmes, nous travaillons en 2024 à une refonte de la plupart des pages de l’application.
+            Nous allons également nous appuyer de plus en plus sur des composants optimisés et réutilisés à travers le site,
+            qui prennent bien en compte les critères d’accessibilité. Enfin, nous allons déployer plus largement le Système de Design de l’Etat (DSFR).
+            Le Schéma Pluri-Annuel 2024-2026 cité plus haut donne plus de détails à ce sujet.
         </p>
         <p>
-            Si dans l’attente de cette refonte ou après, vous rencontrez des blocages pour utiliser le site, vous pouvez nous contacter à xxx
+            Si dans l’attente de cette refonte ou après, vous rencontrez des blocages pour utiliser le site, vous pouvez nous contacter à <a href="mailto:{{ sender_email }}">{{ sender_email }}</a>
         </p>
         <h2>Établissement de cette déclaration d’accessibilité</h2>
-        <p>Cette déclaration a été établie le 2 février 2024.</p>
+        <p>Cette déclaration a été établie le 23 janvier 2025.</p>
         <h3>Technologies utilisées</h3>
         <p>L’accessibilité de {{ request.site.name }} s’appuie sur les technologies suivantes :</p>
         <ul>
@@ -173,26 +163,29 @@
         </p>
         <ul>
             <li>
-                E-mail : <a href="mailto:{{ sender_email }}">{{ sender_email }}</a>
+                E-mail : <a class="correct-link-display" href="mailto:{{ sender_email }}">{{ sender_email }}</a>
             </li>
         </ul>
         <br />
         <p>Nous essayons de répondre dans les 2 jours ouvrés.</p>
         <h2>Voie de recours</h2>
         <p>
-            Cette procédure est à utiliser dans le cas suivant : vous avez signalé au responsable du site internet un défaut d’accessibilité qui vous empêche d’accéder à un contenu ou à un des services du portail et vous n’avez pas obtenu de réponse satisfaisante.
+            Cette procédure est à utiliser dans le cas suivant : vous avez signalé au responsable du site internet un défaut d’accessibilité
+            qui vous empêche d’accéder à un contenu ou à un des services du portail et vous n’avez pas obtenu de réponse satisfaisante.
         </p>
         <p>Vous pouvez :</p>
         <ul>
             <li>
                 Écrire un message au
                 <a href="https://formulaire.defenseurdesdroits.fr/"
+                   class="correct-link-display"
                    target="_blank"
                    rel="noopener">Défenseur des droits</a>
             </li>
             <li>
                 Contacter
                 <a href="https://www.defenseurdesdroits.fr/saisir/delegues"
+                   class="correct-link-display"
                    target="_blank"
                    rel="noopener">le délégué du Défenseur des droits dans votre région</a>
             </li>
@@ -206,7 +199,7 @@
         </ul>
         <hr />
         <p>
-            Cette déclaration d’accessibilité a été créée le 2 février 2024 grâce au
+            Cette déclaration d’accessibilité a été créée le 23 janvier 2025 grâce au
             <a href="https://betagouv.github.io/a11y-generateur-declaration/#create"
                target="_blank"
                rel="noopener">Générateur de Déclaration d’Accessibilité de BetaGouv</a>.


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Modification de la page de déclaration d'accessibilité et de l'affichage des liens contenus dans des balises li pour qu'ils s'affichent comme un lien "normal".

Resolve [#977](https://github.com/betagouv/recommandations-collaboratives/issues/977)

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
