### PR TITLE
[chore] Ajout de prefetch manquants

### DIFF
--- a/recoco/apps/projects/views/administration.py
+++ b/recoco/apps/projects/views/administration.py
@@ -57,9 +57,9 @@ def project_administration(request, project_id):
     """Handle ACL for a project"""
 
     project = get_object_or_404(
-        models.Project.objects.filter(sites=request.site).with_unread_notifications(
-            user_id=request.user.id
-        ),
+        models.Project.objects.filter(sites=request.site)
+        .with_unread_notifications(user_id=request.user.id)
+        .select_related("commune__department"),
         pk=project_id,
     )
 
@@ -276,7 +276,12 @@ def promote_collaborator_as_referent(request, project_id, user_id=None):
 @require_http_methods(["POST"])
 def access_collaborator_invite(request, project_id):
     """Invite a collectivity member"""
-    project = get_object_or_404(models.Project, sites=request.site, pk=project_id)
+
+    project = get_object_or_404(
+        models.Project.objects.select_related("commune__department"),
+        sites=request.site,
+        pk=project_id,
+    )
 
     # can also be a regional actor.
     # FIXME: should we still use allow_national or move to is_staff_for_site?
@@ -378,7 +383,11 @@ def access_collaborator_delete(request, project_id: int, username: str):
 @require_http_methods(["POST"])
 def access_advisor_invite(request, project_id):
     """Invite an advisor"""
-    project = get_object_or_404(models.Project, sites=request.site, pk=project_id)
+    project = get_object_or_404(
+        models.Project.objects.select_related("commune__department"),
+        sites=request.site,
+        pk=project_id,
+    )
 
     # can also be regional actor
     is_regional_actor = is_regional_actor_for_project(
@@ -395,7 +404,11 @@ def access_advisor_invite(request, project_id):
 @require_http_methods(["POST"])
 def access_advisor_resend_invite(request, project_id, invite_id):
     """Resend invitation for an advisor"""
-    project = get_object_or_404(models.Project, sites=request.site, pk=project_id)
+    project = get_object_or_404(
+        models.Project.objects.select_related("commune__department"),
+        sites=request.site,
+        pk=project_id,
+    )
 
     # can also be regional actor
     # FIXME: should we still use allow_national or move to is_staff_for_site?

--- a/recoco/apps/projects/views/detail.py
+++ b/recoco/apps/projects/views/detail.py
@@ -59,9 +59,9 @@ def project_overview(request, project_id=None):
     """Return the details of given project for switchtender"""
 
     project = get_object_or_404(
-        models.Project.objects.filter(sites=request.site).with_unread_notifications(
-            user_id=request.user.id
-        ),
+        models.Project.objects.filter(sites=request.site)
+        .with_unread_notifications(user_id=request.user.id)
+        .select_related("commune__department"),
         pk=project_id,
     )
 
@@ -150,9 +150,9 @@ def project_knowledge(request, project_id=None):
     """Return the survey results for a given project"""
 
     project = get_object_or_404(
-        models.Project.objects.filter(sites=request.site).with_unread_notifications(
-            user_id=request.user.id
-        ),
+        models.Project.objects.filter(sites=request.site)
+        .with_unread_notifications(user_id=request.user.id)
+        .select_related("commune__department"),
         pk=project_id,
     )
 
@@ -200,9 +200,9 @@ def project_actions(request, project_id=None):
     """Action page for given project"""
 
     project = get_object_or_404(
-        models.Project.objects.filter(sites=request.site).with_unread_notifications(
-            user_id=request.user.id
-        ),
+        models.Project.objects.filter(sites=request.site)
+        .with_unread_notifications(user_id=request.user.id)
+        .select_related("commune__department"),
         pk=project_id,
     )
 
@@ -247,7 +247,12 @@ def project_recommendations_embed(request, project_id=None):
 @login_required
 def project_actions_inline(request, project_id=None):
     """Inline Action page for given project"""
-    project = get_object_or_404(models.Project, sites=request.site, pk=project_id)
+
+    project = get_object_or_404(
+        models.Project.objects.select_related("commune__department"),
+        sites=request.site,
+        pk=project_id,
+    )
 
     is_regional_actor = is_regional_actor_for_project(
         request.site, project, request.user, allow_national=True
@@ -267,9 +272,9 @@ def project_conversations(request, project_id=None):
     """Conversation page for project"""
 
     project = get_object_or_404(
-        models.Project.objects.filter(sites=request.site).with_unread_notifications(
-            user_id=request.user.id
-        ),
+        models.Project.objects.filter(sites=request.site)
+        .with_unread_notifications(user_id=request.user.id)
+        .select_related("commune__department"),
         pk=project_id,
     )
 


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée
- [x] Une optimisation

## Décrivez vos changements

La méthode `is_regional_actor_for_project` fait appel à project.commune.department. Un prefetch permet d'éviter des requêtes supplémentaires.

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
