### PR TITLE
[fix] Issue with use of DRF serializers in webhook

### DIFF
--- a/recoco/apps/addressbook/serializers.py
+++ b/recoco/apps/addressbook/serializers.py
@@ -10,7 +10,7 @@ created: 2022-05-16 17:44:55 CET
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import (
     FloatField,
-    # HyperlinkedIdentityField,
+    HyperlinkedIdentityField,
     ModelSerializer,
     SerializerMethodField,
 )
@@ -51,8 +51,7 @@ class OrganizationListSerializer(OrganizationSerializer):
     departments = SerializerMethodField()
     group = OrganizationGroupSerializer(read_only=True)
 
-    # FIXME: https://sentry.incubateur.net/organizations/betagouv/issues/149134/?project=178&query=is%3Aunresolved&referrer=issue-stream&stream_index=0
-    # _link = HyperlinkedIdentityField(view_name="api-addressbook-organization-detail")
+    _link = HyperlinkedIdentityField(view_name="api-addressbook-organization-detail")
     _search_rank = FloatField(source="search_rank", read_only=True)
 
     class Meta:
@@ -62,7 +61,7 @@ class OrganizationListSerializer(OrganizationSerializer):
             "name",
             "group",
             "departments",
-            # "_link",
+            "_link",
             "_search_rank",
         ]
 
@@ -87,7 +86,7 @@ class NestedOrganizationSerializer(OrganizationListSerializer):
         fields = [
             "id",
             "name",
-            # "_link",
+            "_link",
         ]
 
 
@@ -116,7 +115,7 @@ class ContactSerializer(BaseSerializerMixin, ModelSerializer):
 class ContactListSerializer(ContactSerializer):
     organization = NestedOrganizationSerializer(read_only=True, many=False)
 
-    # _link = HyperlinkedIdentityField(view_name="api-addressbook-contact-detail")
+    _link = HyperlinkedIdentityField(view_name="api-addressbook-contact-detail")
     _search_rank = FloatField(source="search_rank", read_only=True)
 
     class Meta:
@@ -132,7 +131,7 @@ class ContactListSerializer(ContactSerializer):
             "organization",
             "created",
             "modified",
-            # "_link",
+            "_link",
             "_search_rank",
         ]
         read_only_fields = fields
@@ -167,6 +166,6 @@ class NestedContactSerializer(ContactListSerializer):
             "mobile_no",
             "division",
             "organization",
-            # "_link",
+            "_link",
         ]
         read_only_fields = fields

--- a/recoco/apps/webhook/signals.py
+++ b/recoco/apps/webhook/signals.py
@@ -36,11 +36,13 @@ class WebhookSignalListener(SignalListener):
         )
 
     def model_dict(self, instance: Any) -> dict[str, Any]:
+        kwargs = {"context": {"request": None}}
+
         if isinstance(instance, Project):
-            return ProjectSerializer(instance).data
+            return ProjectSerializer(instance, **kwargs).data
         if isinstance(instance, Answer):
-            return AnswerSerializer(instance).data
+            return AnswerSerializer(instance, **kwargs).data
         if isinstance(instance, TaggedItem):
             if isinstance(project := instance.content_object, Project):
-                return ProjectSerializer(project).data
+                return ProjectSerializer(project, **kwargs).data
         return {}


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

J'avais désactivé les champs `_link` des payloads de l'API, à cause d'une erreur sur la partie webhook, qui utilise les serializers DRF, mais sans contexte.
J'ai fait ce fix pour les réactiver, en ajoutant un test coté webhook.

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
