### PR TITLE
[feat] Ouverture des notification dans un nouvel onglet possible

### DIFF
--- a/recoco/frontend/src/js/components/MenuNotifications.js
+++ b/recoco/frontend/src/js/components/MenuNotifications.js
@@ -19,7 +19,10 @@ function MenuNotifications(notificationNumber, listNofification) {
     async clickConsummeNotificationAndRedirect(notificationId, targetUrl) {
       await api.patch(notificationsMarkAsReadByIdUrl(notificationId), {});
       // redirect to the notification target
-      window.location.href = targetUrl;
+      window.open(`${window.location.origin}${targetUrl}`, '_blank');
+    },
+    getNotificationLink(targetUrl) {
+      return `${window.location.origin}${targetUrl}`;
     },
     async markNotificationAsRead(notificationId, el, notificationIndex) {
       try {

--- a/recoco/templates/default_site/header/dropdown-menu-notifications.html
+++ b/recoco/templates/default_site/header/dropdown-menu-notifications.html
@@ -25,7 +25,7 @@
                     x-init='initNewNotification(`${ {{ forloop.counter }}{{ forloop.parentloop.counter0 }} }`)'
                     x-show="isNotificationShown[`${ {{ forloop.counter }}{{ forloop.parentloop.counter0 }} }`]"
                     x-transition.duration.400ms>
-                    <a href="javascript:void(0);"
+                    <a :href="getNotificationLink({% if notification.verb == verbs.Recommendation.COMMENTED %}'{{ notification.action_object.task.get_absolute_url }}' {% elif notification.verb == verbs.Survey.STARTED or notification.verb == verbs.Survey.UPDATED %} `{{ notification.target.get_absolute_url }}connaissance` {% else %}'{{ notification.action_object.get_absolute_url }}' {% endif %})"
                        @click="clickConsummeNotificationAndRedirect({{ notification.pk }}, {% if notification.verb == verbs.Recommendation.COMMENTED %}'{{ notification.action_object.task.get_absolute_url }}' {% elif notification.verb == verbs.Survey.STARTED or notification.verb == verbs.Survey.UPDATED %} `{{ notification.target.get_absolute_url }}connaissance` {% else %}'{{ notification.action_object.get_absolute_url }}' {% endif %})">
                         {% include "user/user_card.html" with user=notification.actor project=notification.target user_popup_deactivate=True user_activity=False disable_links=True %}
                         {% if notification.verb == verbs.Project.VALIDATED %}


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Il est maintenant possible d'ouvrir les notifications à l'aide d'un : 
- `Ctr+click`
- `Cmd+click` 
- menu contextuel

pour l'ouvrir dans un nouvel onglet.

Resolve #995 
## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
