### PR TITLE
[feat] Contact API : filtrer sur les noms d'organisation et recherche par email

### DIFF
--- a/recoco/apps/addressbook/apps.py
+++ b/recoco/apps/addressbook/apps.py
@@ -21,6 +21,7 @@ class AddressbookConfig(AppConfig):
             fields=(
                 "last_name",
                 "first_name",
+                "email",
                 "division",
                 "organization__name",
                 "organization__group__name",

--- a/recoco/apps/addressbook/rest.py
+++ b/recoco/apps/addressbook/rest.py
@@ -1,3 +1,4 @@
+from rest_framework.filters import BaseFilterBackend
 from rest_framework.viewsets import ModelViewSet
 from waffle import switch_is_active
 
@@ -42,9 +43,18 @@ class OrganizationViewSet(ModelViewSet):
                 return serializers.OrganizationSerializer
 
 
+class OrgaStartswithFilterBackend(BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        orga_sw = request.query_params.get("orga-startswith")
+        if not orga_sw:
+            return queryset
+        return queryset.filter(organization__name__istartswith=orga_sw)
+
+
 class ContactViewSet(ModelViewSet):
     permission_classes = [IsStaffForSiteOrISAuthenticatedReadOnly]
     pagination_class = StandardResultsSetPagination
+    filter_backends = [OrgaStartswithFilterBackend]
 
     search_fields = [
         (
@@ -53,6 +63,10 @@ class ContactViewSet(ModelViewSet):
         ),
         (
             "first_name",
+            {"config": "french", "weight": "A"},
+        ),
+        (
+            "email",
             {"config": "french", "weight": "A"},
         ),
         (


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

- filtre sur le nom de l'organisation, type "startswith": `/api/addressbook/contacts/?orga-startswith=B`
- l'email du contact est désormais pris en compte dans la recherche

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
