### PR TITLE
[fix] Bug sur le slug du model Question

### DIFF
--- a/recoco/apps/survey/models.py
+++ b/recoco/apps/survey/models.py
@@ -137,7 +137,7 @@ class Question(CloneMixin, models.Model):
     """A question with mutliple choices"""
 
     objects = QuestionManager()
-    objects_deleted = models.Manager()
+    objects_all = models.Manager()
 
     precondition = TagField(
         verbose_name="Pré-condition",
@@ -162,7 +162,11 @@ class Question(CloneMixin, models.Model):
     def _populate_slug(self) -> str:
         return self.text_short if len(self.text_short) else self.text
 
-    slug = AutoSlugField(unique=True, populate_from=_populate_slug)
+    slug = AutoSlugField(
+        unique=True,
+        populate_from=_populate_slug,
+        manager=objects_all,
+    )
 
     how = models.TextField(default="", blank=True, verbose_name="Comment ?")
 

--- a/recoco/apps/survey/tests/test_edit.py
+++ b/recoco/apps/survey/tests/test_edit.py
@@ -264,7 +264,7 @@ def test_question_delete_and_redirect(request, client):
     with login(client, groups=["example_com_admin"]):
         response = client.post(url)
 
-    question = models.Question.objects_deleted.get(id=question.id)
+    question = models.Question.objects_all.get(id=question.id)
     assert question.deleted
 
     new_url = reverse(

--- a/recoco/apps/survey/tests/test_models.py
+++ b/recoco/apps/survey/tests/test_models.py
@@ -8,6 +8,7 @@ created: 2021-06-27 12:06:10 CEST
 """
 
 import pytest
+from django.utils import timezone
 from model_bakery.recipe import Recipe
 
 from .. import models, utils
@@ -272,6 +273,16 @@ def test_question_slug():
         text_short="Description précise",
     )
     assert q.slug == "description-precise-2"
+
+    q.deleted = timezone.now()
+    q.save()
+
+    q = models.Question.objects.create(
+        question_set=q_set,
+        text="Description précise de l'Action ?",
+        text_short="Description précise",
+    )
+    assert q.slug == "description-precise-3"
 
 
 ########################################################################


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

Pour vérifier l'unicité, le champ slug s'appuyait sur le manager par défaut, qui exclue les questions marquées comme `deleted`. Désormais, il prend en compte toutes les questions existantes.

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
