### PR TITLE
[fix] N+1 pluralize

### DIFF
--- a/recoco/apps/crm/templates/crm/organization_list.html
+++ b/recoco/apps/crm/templates/crm/organization_list.html
@@ -55,7 +55,11 @@
                     <table class="table table-striped table-hover caption-top">
                         <div class="d-flex justify-content-between fr-mx-2v">
                             {% with organizations.qs.count as organizations_count %}
-                            <span class="fr-ml-2v text-secondary">{{ organizations_count }} résultat{{ organizations_count|pluralize }}</span>
+                                {% if organizations_count > 0 %}
+                                    <span class="fr-ml-2v text-secondary">{{ organizations_count }} résultat{{ organizations_count|pluralize }}</span>
+                                {% else %}
+                                    <caption class="fr-ml-2v">Aucun résultat</caption>
+                                {% endif %}
                             {% endwith %}
                             <div class="btn-group">
                                 <button class="btn btn-outline-primary">Fusionner</button>

--- a/recoco/apps/crm/templates/crm/project_list.html
+++ b/recoco/apps/crm/templates/crm/project_list.html
@@ -77,7 +77,13 @@
             </div>
             <div class="fr-mb-2w table-responsive">
                 <table class="table table-striped table-hover caption-top">
-                    <caption class="fr-ml-2v">{{ projects.qs.count }} résultat{{ projects.qs.count|pluralize }}</caption>
+                    {% with projects.qs.count as projects_count %}
+                        {% if projects_count > 0 %}
+                            <caption class="fr-ml-2v">{{ projects_count }} résultat{{ projects_count|pluralize }}</caption>
+                        {% else %}
+                            <caption class="fr-ml-2v">Aucun résultat</caption>
+                        {% endif %}
+                    {% endwith %}
                     <thead>
                         <tr>
                             <th scope="col">Nom</th>

--- a/recoco/apps/crm/templates/crm/user_list.html
+++ b/recoco/apps/crm/templates/crm/user_list.html
@@ -94,7 +94,13 @@
             </div>
             <div class="fr-mb-2w" class="table-responsive">
                 <table class="table table-striped table-hover caption-top">
-                    <caption class="fr-ml-2v">{{ users.qs.count }} résultat{{ users.qs.count|pluralize }}</caption>
+                    {% with users.qs.count as users_count %}
+                        {% if users_count > 0 %}
+                            <caption class="fr-ml-2v">{{ users_count }} résultat{{ users_count|pluralize }}</caption>
+                        {% else %}
+                            <caption class="fr-ml-2v">Aucun résultat</caption>
+                        {% endif %}
+                    {% endwith %}
                     <thead>
                         <tr>
                             <th scope="col">Identifiant de connexion</th>

--- a/recoco/apps/projects/templates/projects/project/documents.html
+++ b/recoco/apps/projects/templates/projects/project/documents.html
@@ -33,8 +33,10 @@
                         <div class="col-8">
                             <div class="d-flex align-items-center justify-content-between fr-mb-3w">
                                 <h6 class="text-uppercase small fr-mb-0">
-                                    {% if all_files.count > 0 %}{{ all_files.count }}{% endif %}
-                                    fichier{{ all_files.count|pluralize }} partagé{{ all_files.count|pluralize }}
+                                    {% with all_files.count as files_count %}
+                                        {% if files_count > 0 %}{{ files_count }}{% endif %}
+                                        fichier{{ files_count|pluralize }} partagé{{ files_count|pluralize }}
+                                    {% endwith %}
                                 </h6>
                                 {% if "manage_documents" in user_project_perms %}
                                     {% url 'projects-documents-upload-document' project.pk as upload_action %}

--- a/recoco/apps/projects/templates/projects/project/list-map.html
+++ b/recoco/apps/projects/templates/projects/project/list-map.html
@@ -19,9 +19,11 @@
                         <use xlink:href="{% static 'svg/bootstrap-icons.svg'  %}#binoculars" />
                     </svg>
                     <span class="align-middle">
-                        {% if draft_projects.count %}
-                            <a href="#draft-projects">{{ draft_projects.count }} projet{{ draft_projects|pluralize }}</a> en attente d'acceptation
-                        {% endif %}
+                        {% with draft_projects.count as draft_projects_count %}
+                            {% if draft_projects_count > 0 %}
+                                <a href="#draft-projects">{{ draft_projects_count }} projet{{ draft_projects_count|pluralize }}</a> en attente d'acceptation
+                            {% endif %}
+                        {% endwith %}
                     </span>
                     -
                 {% endif %}

--- a/recoco/apps/resources/templates/resources/resource/list.html
+++ b/recoco/apps/resources/templates/resources/resource/list.html
@@ -175,7 +175,7 @@
                 {% else %}
                     <div class="col-12">
                         <span class="text-secondary">
-                            {{ resources_count }} résultat{{ resources|pluralize }} trouvé{{ resources|pluralize }} pour "<em>{{ query }}</em>".
+                            {{ resources_count }} résultat{{ resources_count|pluralize }} trouvé{{ resources_count|pluralize }} pour "<em>{{ query }}</em>".
                         </span>
                     </div>
                 {% endif %}

--- a/recoco/apps/survey/templates/survey/editor/survey/details.html
+++ b/recoco/apps/survey/templates/survey/editor/survey/details.html
@@ -84,9 +84,11 @@
                         </div>
                         <span class="align-middle text-secondary">{{ question_set.subheading }}</span>
                     </div>
-                    {% if question_set.questions.count %}
-                        <span class="badge bg-primary rounded-pill">{{ question_set.questions.count }} question{{ question_set.questions.count|pluralize }}</span>
-                    {% endif %}
+                    {% with question_set.questions.count as questions_count %}
+                        {% if questions_count > 0 %}
+                            <span class="badge bg-primary rounded-pill">{{ questions_count }} question{{ questions_count|pluralize }}</span>
+                        {% endif %}
+                    {% endwith %}
                 </li>
             {% endfor %}
         </ul>


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

Aux endroit où on utilise le templatetag `pluralize`, on fait souvent 2 requêtes de type `count` inutilement.

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
