### PR TITLE
[fix] Revert change on watson french config

### DIFF
--- a/recoco/settings/common.py
+++ b/recoco/settings/common.py
@@ -560,10 +560,4 @@ WAFFLE_FLAG_MODEL = "feature_flag.Flag"
 WAFFLE_SWITCH_MODEL = "feature_flag.Switch"
 WAFFLE_SAMPLE_MODEL = "feature_flag.Sample"
 
-
-# Watson
-
-# https://github.com/etianen/django-watson/wiki/language-support
-WATSON_POSTGRES_SEARCH_CONFIG = "pg_catalog.french"
-
 # eof


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

Ce changement fait échouer le test `test_crm_project_list_filters_by_project_name`

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
