### PR TITLE
[fix] Mistake with username vs email

### DIFF
--- a/recoco/apps/invites/tests.py
+++ b/recoco/apps/invites/tests.py
@@ -193,7 +193,7 @@ def test_invite_does_not_match_existing_account(request, client):
 def test_invite_matches_existing_account_for_logged_in_user(request, client):
     current_site = get_current_site(request)
     baker.make(home_models.SiteConfiguration, site=current_site)
-    with login(client) as user:
+    with login(client, email="invited@here.tld", username="invited@here.tld") as user:
         invite = Recipe(models.Invite, site=current_site, email=user.email).make()
         url = reverse("invites-invite-details", args=[invite.pk])
         response = client.get(url)
@@ -209,7 +209,7 @@ def test_invite_matches_existing_account_redirects_anonyous_user_to_login(
     current_site = get_current_site(request)
     baker.make(home_models.SiteConfiguration, site=current_site)
     invited = Recipe(
-        auth_models.User, username="invited", email="invited@example.com"
+        auth_models.User, username="invited@example.com", email="invited@example.com"
     ).make()
 
     invite = Recipe(models.Invite, site=current_site, email=invited.email).make()
@@ -239,7 +239,7 @@ def test_accept_invite_returns_to_details_if_get(request, client):
 def test_accept_invite_matches_existing_account(request, client, project):
     current_site = get_current_site(request)
     baker.make(home_models.SiteConfiguration, site=current_site)
-    with login(client) as user:
+    with login(client, email="invited@here.tld", username="invited@here.tld") as user:
         invite = Recipe(
             models.Invite, project=project, site=current_site, email=user.email
         ).make()
@@ -261,7 +261,7 @@ def test_accept_invite_as_switchtender_triggers_notification(request, client, pr
     )
     project.projectmember_set.add(membership)
 
-    with login(client) as user:
+    with login(client, email="invited@here.tld", username="invited@here.tld") as user:
         user.profile.sites.add(current_site)
         invite = Recipe(
             models.Invite,
@@ -288,7 +288,7 @@ def test_accept_invite_as_team_member_triggers_notification(request, client, pro
 
     project.projectmember_set.add(membership)
 
-    with login(client) as user:
+    with login(client, email="invited@here.tld", username="invited@here.tld") as user:
         invite = Recipe(
             models.Invite,
             project=project,
@@ -336,7 +336,7 @@ def test_logged_in_user_accepts_invite_advisor_with_matching_existing_account(
     current_site = get_current_site(request)
     baker.make(home_models.SiteConfiguration, site=current_site)
 
-    with login(client, email="invited@here.tld") as user:
+    with login(client, email="invited@here.tld", username="invited@here.tld") as user:
         invite = Recipe(
             models.Invite,
             site=current_site,
@@ -365,7 +365,7 @@ def test_logged_in_user_accepts_invite_observer_with_matching_existing_account(
     current_site = get_current_site(request)
     baker.make(home_models.SiteConfiguration, site=current_site)
 
-    with login(client, email="invited@here.tld") as user:
+    with login(client, email="invited@here.tld", username="invited@here.tld") as user:
         invite = Recipe(
             models.Invite,
             site=current_site,
@@ -424,7 +424,7 @@ def test_logged_in_user_accepts_invite_collaborator_with_matching_existing_accou
 ):
     current_site = get_current_site(request)
     baker.make(home_models.SiteConfiguration, site=current_site)
-    with login(client, email="invited@here.tld") as user:
+    with login(client, email="invited@here.tld", username="invited@here.tld") as user:
         invite = Recipe(
             models.Invite,
             role="COLLABORATOR",
@@ -483,7 +483,7 @@ def test_anonymous_accepts_invite_with_existing_account_fails(
     baker.make(home_models.SiteConfiguration, site=current_site)
 
     invited = Recipe(
-        auth_models.User, username="invited", email="invited@example.com"
+        auth_models.User, username="invited@example.com", email="invited@example.com"
     ).make()
 
     invite = Recipe(
@@ -642,7 +642,7 @@ def test_accepting_invitation_updates_organization_with_current_site(
 def test_logged_in_user_accepts_invite_but_is_already_member(request, client, project):
     current_site = get_current_site(request)
     baker.make(home_models.SiteConfiguration, site=current_site)
-    with login(client, email="invited@here.tld") as user:
+    with login(client, email="invited@here.tld", username="invited@here.tld") as user:
         invite = Recipe(
             models.Invite,
             role="COLLABORATOR",
@@ -670,7 +670,7 @@ def test_logged_in_user_accepts_invite_but_is_already_advisor(
 ):
     current_site = get_current_site(request)
     baker.make(home_models.SiteConfiguration, site=current_site)
-    with login(client, email="invited@here.tld") as user:
+    with login(client, email="invited@here.tld", username="invited@here.tld") as user:
         invite = Recipe(
             models.Invite,
             role="OBSERVER",

--- a/recoco/apps/invites/views.py
+++ b/recoco/apps/invites/views.py
@@ -27,7 +27,7 @@ def invite_accept(request, invite_id):
     # Check if this email already exists as an account
     existing_account = None
     try:
-        existing_account = auth_models.User.objects.get(email=invite.email)
+        existing_account = auth_models.User.objects.get(username=invite.email)
     except auth_models.User.DoesNotExist:
         pass
 
@@ -105,7 +105,7 @@ def invite_details(request, invite_id):
     # Check if this email already exists as an account
     existing_account = None
     try:
-        existing_account = auth_models.User.objects.get(email=invite.email)
+        existing_account = auth_models.User.objects.get(username=invite.email)
     except auth_models.User.DoesNotExist:
         pass
 

--- a/recoco/apps/projects/tests/test_project_inactive.py
+++ b/recoco/apps/projects/tests/test_project_inactive.py
@@ -287,7 +287,11 @@ def test_notifications_are_not_dispatched_to_collaborators_if_project_is_inactiv
     collaborator = baker.make(auth_models.User, email="collab@notif.com")
     assign_collaborator(collaborator, project)
 
-    invited_collab = baker.make(auth_models.User, email="invited_collab@notif.com")
+    invited_collab = baker.make(
+        auth_models.User,
+        email="invited_collab@notif.com",
+        username="invited_collab@notif.com",
+    )
 
     advisor = baker.make(auth_models.User, email="advisor@notif.com")
     assign_advisor(advisor, project, site)

--- a/recoco/apps/social_account/adapters.py
+++ b/recoco/apps/social_account/adapters.py
@@ -27,7 +27,7 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
             return
 
         try:
-            user = User.objects.get(email=user.email)
+            user = User.objects.get(username=user.email)
             sociallogin.connect(request, user)
         except User.DoesNotExist:
             pass

--- a/recoco/apps/social_account/provider.py
+++ b/recoco/apps/social_account/provider.py
@@ -19,6 +19,7 @@ class ProConnectProvider(OpenIDConnectProvider):
         Override this method to extract common fields from the data
         """
         return super().extract_common_fields(data) | {
+            "username": data.get("email", ""),
             "siret": data.get("siret", ""),
             "first_name": data.get("given_name", ""),
             "last_name": data.get("usual_name", ""),


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

Le champ `email` n'étant pas unique pour un `User`, on doit faire un get en prenant le champ `username`, qui doit contenir l'email.

Ca doit fixer [ce bug sentry](https://sentry.incubateur.net/organizations/betagouv/issues/160028/?environment=production&project=178&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=1)

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
