### PR TITLE
Changement de l'url par défaut de la page de prévisualisation des projets pour les conseiller.res

### DIFF
--- a/recoco/apps/projects/tests/test_projects.py
+++ b/recoco/apps/projects/tests/test_projects.py
@@ -137,7 +137,8 @@ def test_project_list_not_available_for_non_staff_users(client):
 
 @pytest.mark.django_db
 def test_project_list_available_for_switchtender_user(request, client):
-    get_current_site(request)
+    current_site = get_current_site(request)
+    baker.make(home_models.SiteConfiguration, site=current_site)
     url = reverse("projects-project-list")
     with login(client, groups=["example_com_staff", "example_com_advisor"]):
         response = client.get(url, follow=True)

--- a/recoco/apps/projects/tests/test_projects.py
+++ b/recoco/apps/projects/tests/test_projects.py
@@ -150,12 +150,27 @@ def test_project_list_available_for_switchtender_user(request, client):
 
 
 @pytest.mark.django_db
+def test_project_list_available_for_advisor(request, client):
+    current_site = get_current_site(request)
+    baker.make(home_models.SiteConfiguration, site=current_site)
+
+    url = reverse("projects-project-list")
+    with login(client, groups=["example_com_advisor"]):
+        response = client.get(url, follow=True)
+
+    staff_url = reverse("projects-project-list-staff")
+    url, code = response.redirect_chain[-1]
+    assert code == 302
+    assert url == staff_url
+
+
+@pytest.mark.django_db
 def test_project_list_available_for_staff(request, client):
     current_site = get_current_site(request)
     baker.make(home_models.SiteConfiguration, site=current_site)
 
     url = reverse("projects-project-list")
-    with login(client, groups=["example_com_staff", "example_com_advisor"]):
+    with login(client, groups=["example_com_staff"]):
         response = client.get(url, follow=True)
 
     staff_url = reverse("projects-project-list-staff")

--- a/recoco/apps/projects/tests/test_projects.py
+++ b/recoco/apps/projects/tests/test_projects.py
@@ -139,7 +139,7 @@ def test_project_list_not_available_for_non_staff_users(client):
 def test_project_list_available_for_switchtender_user(request, client):
     get_current_site(request)
     url = reverse("projects-project-list")
-    with login(client, groups=["example_com_advisor"]):
+    with login(client, groups=["example_com_staff", "example_com_advisor"]):
         response = client.get(url, follow=True)
 
     advisor_url = reverse("projects-project-list-staff")

--- a/recoco/apps/projects/tests/test_projects.py
+++ b/recoco/apps/projects/tests/test_projects.py
@@ -142,7 +142,7 @@ def test_project_list_available_for_switchtender_user(request, client):
     with login(client, groups=["example_com_advisor"]):
         response = client.get(url, follow=True)
 
-    advisor_url = reverse("projects-project-list-advisor")
+    advisor_url = reverse("projects-project-list-staff")
     url, code = response.redirect_chain[-1]
     assert code == 302
     assert url == advisor_url

--- a/recoco/apps/projects/views/__init__.py
+++ b/recoco/apps/projects/views/__init__.py
@@ -211,12 +211,12 @@ def project_moderation_accept(request, project_pk):
 # ----
 @login_required
 def project_list(request):
-    if is_staff_for_site(request.user, request.site):
+    if is_staff_for_site(request.user, request.site) or check_if_advisor(
+        request.user, request.site
+    ):
         return redirect("projects-project-list-staff")
 
-    if check_if_advisor(request.user, request.site) or can_administrate_project(
-        project=None, user=request.user
-    ):
+    if can_administrate_project(project=None, user=request.user):
         return redirect("projects-project-list-advisor")
 
     raise PermissionDenied("Vous n'avez pas le droit d'accéder à ceci.")


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Changement de l'url par défaut lorsque l'on veut accéder à tous les projets pour que les conseiller.es arrivent sur la vue kanban au lieu de la vue liste.

Pour info, je n'ai pas changer le nom des urls, mais ça fait un peu bizarre de rediriger les advisor vers l'url staff.

Resolve #1128 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
