### PR TITLE
[feat] Permission followups conseillers

### DIFF
--- a/recoco/apps/tasks/tests/test_rest_task_followup.py
+++ b/recoco/apps/tasks/tests/test_rest_task_followup.py
@@ -5,12 +5,13 @@ from model_bakery import baker
 
 from recoco.apps.addressbook.models import Contact
 from recoco.apps.projects import utils
+from recoco.utils import get_group_for_site
 
 from .. import models
 
 
 @pytest.mark.django_db
-def test_project_task_followup_list_closed_to_anonymous_user(
+def test_project_task_followup_list_not_allowed_to_anonymous_user(
     api_client, current_site, project
 ):
     task = baker.make(models.Task, project=project, site=current_site, public=True)
@@ -22,7 +23,7 @@ def test_project_task_followup_list_closed_to_anonymous_user(
 
 
 @pytest.mark.django_db
-def test_project_task_followup_list_closed_to_user_wo_permission(
+def test_project_task_followup_list_not_allowed_to_user_wo_permission(
     api_client, current_site, project
 ):
     user = baker.make(auth_models.User)
@@ -89,7 +90,7 @@ def test_project_task_followup_list_returns_followups_to_collaborator(
 
 
 @pytest.mark.django_db
-def test_project_task_followup_create_closed_to_anonymous_user(
+def test_project_task_followup_create_not_allowed_to_anonymous_user(
     api_client, current_site, project
 ):
     task = baker.make(models.Task, project=project, site=current_site, public=True)
@@ -101,10 +102,27 @@ def test_project_task_followup_create_closed_to_anonymous_user(
 
 
 @pytest.mark.django_db
-def test_project_task_followup_create_not_allowed_for_simple_auth_user(
+def test_project_task_followup_create_not_allowed_to_simple_auth_user(
     api_client, current_site, project
 ):
     user = baker.make(auth_models.User)
+    task = baker.make(models.Task, project=project, site=current_site, public=True)
+
+    api_client.force_authenticate(user=user)
+    url = reverse("project-tasks-followups-list", args=[project.id, task.id])
+    response = api_client.post(url, data={"comment": "a new followup for tasks"})
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_project_task_followup_create_not_allowed_to_external_advisor(
+    api_client, current_site, project
+):
+    user = baker.make(auth_models.User)
+    user.profile.sites.add(current_site)
+    user.groups.add(get_group_for_site("advisor", current_site))
+
     task = baker.make(models.Task, project=project, site=current_site, public=True)
 
     api_client.force_authenticate(user=user)
@@ -155,7 +173,7 @@ def test_project_task_followup_create_is_processed_for_auth_user(
 
 
 @pytest.mark.django_db
-def test_project_task_followup_update_closed_to_anonymous_user(
+def test_project_task_followup_update_not_allowed_to_anonymous_user(
     api_client, current_site, project
 ):
     task = baker.make(models.Task, project=project, site=current_site, public=True)


### PR DESCRIPTION

Il s'agit de :
- [ ] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

Un conseiller peut désormais lire les followups d'un projet sur lequel il n'est pas positionné.
https://github.com/betagouv/recommandations-collaboratives/issues/1061


## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
