### PR TITLE
[fix] Correction de la modification du commentaire initial d'une recommandation en brouillon

### DIFF
--- a/recoco/apps/projects/static/projects/css/fragments/tasks_modal/modal.scss
+++ b/recoco/apps/projects/static/projects/css/fragments/tasks_modal/modal.scss
@@ -62,8 +62,20 @@
   right: 1rem;
 }
 
+.repositionning-in-modal-non-public {
+  bottom: 6rem;
+  position: absolute;
+  right: 1rem;
+}
+
 .button-cancel-edit {
   position: absolute;
   bottom: 1rem;
+  right: 6.5rem;
+}
+
+.button-cancel-edit-non-public {
+  position: absolute;
+  bottom: 6rem;
   right: 6.5rem;
 }

--- a/recoco/apps/projects/templates/projects/project/fragments/task/task_comment.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/task/task_comment.html
@@ -31,7 +31,7 @@
             <button class="fr-btn fr-btn--sm fr-btn--tertiary fr-icon-close-line position-absolute top-0 end-0 fr-m-2w"
                     @click.stop="isEditing = false">Annuler la modification</button>
             <form @submit.prevent="handleEditComment(task)" novalidate>
-                {% include "tools/editor.html" with model="comment" initial_content="task.content" %}
+                {% include "tools/editor.html" with model="comment" initial_content="task.content" initial_content_js=True %}
                 <button @click.stop
                         type="submit"
                         class="fr-btn fr-btn--sm repositionning"

--- a/recoco/apps/projects/templates/projects/project/fragments/tasks_modal/task_modal.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/tasks_modal/task_modal.html
@@ -110,7 +110,7 @@
                                                     <span class="text-muted tiny specific-lineheight-20"
                                                           x-text="`le ${formatDate(currentTask?.created_on)}`"></span>
                                                 </div>
-                                                <template x-if="$store.djangoData.canManageTasks">
+                                                <template x-if="$store.djangoData.canManageTasks && currentTask.public">
                                                     <button class="text-muted cursor-pointer tiny" @click="onEditContent()">Editer</button>
                                                 </template>
                                             </div>
@@ -192,10 +192,12 @@
                                         <template x-if="currentlyEditing">
                                             <button type="button"
                                                     class="fr-btn fr-btn--sm fr-btn--tertiary button-cancel-edit"
+                                                    :class="!currentTask.public ? 'button-cancel-edit-non-public' : 'button-cancel-edit'"
                                                     @click="onCancelEdit()">Annuler</button>
                                         </template>
                                         <button type="submit"
-                                                class="fr-btn fr-btn--sm repositionning-in-modal"
+                                                class="fr-btn fr-btn--sm "
+                                                :class="!currentTask.public ? 'repositionning-in-modal-non-public' : 'repositionning-in-modal'"
                                                 data-test-id="button-submit-new"
                                                 x-text="currentlyEditing ? 'Modifier' : 'Envoyer'"></button>
                                     </div>

--- a/recoco/templates/default_site/tools/editor.html
+++ b/recoco/templates/default_site/tools/editor.html
@@ -20,7 +20,7 @@ Parameters:
 {% endblock css %}
 {% comment %} TODO @set-comment.window to fix{% endcomment %}
 <div class="w-100"
-     {% if initial_content_escapejs %} x-data='editor("{{ initial_content|escapejs }}")' {% else %} x-data='editor("{{ initial_content }}")' {% endif %}
+     {% if initial_content_escapejs %} x-data='editor("{{ initial_content|escapejs }}")' {% elif initial_content_js %} x-data='editor({{ initial_content }})' {% else %} x-data='editor("{{ initial_content }}")' {% endif %}
      @reset-contact="handleResetContact()"
      @set-comment.window="setMarkdownContent(event)"
      @modal-response="closeSearchContactModal($event)"


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Correction de l'édition d'un commentaire initial dans la liste des recommandations de l'onglet recommandation d'un projet et dans la fenêtre modal de prévisualisation d'une recommandation.

Dans le premier cas, le contenu du commentaire initial à modifier devenait "text.content" lors de l'édition. Le problème est résolu et affiche maintenant le contenu du commentaire initial.

Dans le second cas, le contenu n'apparaissait pas. Le problème est résolu en cachant le bouton d'édition dans la fenêtre modal pour le commentaire initial. Il aurait été trop long de le corriger en faisant apparaître proprement le message car l'éditeur n'existe pas encore lorsque l'on clique sur éditer et que l'on veut transmettre le contenu du commentaire initial.

Ajout de classe pour le bon placement de bouton lors de l'édition d'un commentaire en brouillon.

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
