### PR TITLE
[fix] Bug de création des projets en double

### DIFF
--- a/frontend_tests/README.md
+++ b/frontend_tests/README.md
@@ -188,7 +188,7 @@ Merci de mettre à jour la colonne `Utilisé` en fonction de l'utilisation du co
 | Projet - Paramètres        | `/project/{id}/administration` | Gestion invitation                                 | `// @page-projet-parametres-gestion-invitation`     |      ❌ |
 | Projet - Paramètres        | `/project/{id}/administration` | Mettre projet en pause                             | `// @page-projet-parametres-pause-projet`           |      ❌ |
 | Projet - Paramètres        | `/project/{id}/administration` | Quitter le projet                                  | `// @page-projet-parametres-quitter-projet`         |      ❌ |
-| Déposer un projet          | `/onboarding/project`          | Page                                               | `// @deposer-projet`                                |      ❌ |
+| Déposer un projet          | `/onboarding/project`          | Page                                               | `// @deposer-projet`                                |      🚧 |
 
 Le code est a positionner dans les fichiers de tests Cypress dans le nom du test pour permettre de retrouver facilement les tests concernés et de les executer selectivement à l'aide du package @cypress/grep.
 

--- a/frontend_tests/cypress/e2e/header/canCreateANewProject.cy.js
+++ b/frontend_tests/cypress/e2e/header/canCreateANewProject.cy.js
@@ -1,4 +1,4 @@
-describe('I can create a new project from the main header project list dropdown', () => {
+describe('I can create a new project from the main header project list dropdown @deposer-projet', () => {
   it('display button as a collectivity', () => {
     cy.login('collectivité1');
     cy.visit(`/`);

--- a/frontend_tests/cypress/e2e/project/collectivity/canCreateAProject.cy.js
+++ b/frontend_tests/cypress/e2e/project/collectivity/canCreateAProject.cy.js
@@ -1,4 +1,4 @@
-describe('I can follow a project', () => {
+describe('I can follow a project @deposer-projet', () => {
   it('goes to the homepage and create a project with the main CTA', () => {
     cy.login('collectivité1');
     cy.createProject('fake project name');

--- a/frontend_tests/cypress/support/commands.js
+++ b/frontend_tests/cypress/support/commands.js
@@ -192,7 +192,7 @@ Cypress.Commands.add('createProject', (label, objProject = project) => {
     .should('have.value', objProject.description || project.description)
     .should('have.class', 'fr-input--valid');
 
-  cy.get('button[type="submit"]').click();
+  cy.get('button[type="submit"]').click().should('be.disabled');
 
   cy.url().should('include', '/onboarding/summary');
 

--- a/recoco/apps/dsrc/templates/dsrc/core/blocks/buttons/button_group.html
+++ b/recoco/apps/dsrc/templates/dsrc/core/blocks/buttons/button_group.html
@@ -11,6 +11,7 @@
             <button type="submit"
                     class="fr-btn dsrc-color--primary w-100"
                     x-on:click="validate"
+                    :disabled="!isFormEdited && !canSubmit"
                     {% if disabled %}disabled=""{% endif %}>{{ form.helper.action_button.submit.label }}</button>
         </li>
     {% endif %}

--- a/recoco/apps/onboarding/templates/onboarding/fragments/form-project.html
+++ b/recoco/apps/onboarding/templates/onboarding/fragments/form-project.html
@@ -1,7 +1,8 @@
 {% load crispy_forms_tags %}
 <form id="{{ form.helper.form_id }}"
       method="post"
-      enctype="multipart/form-data">
+      enctype="multipart/form-data"
+      x-on:input="isFormEdited = true">
     <input type="hidden"
            name="js_enabled"
            id="{{ form.helper.form_id }}_js_enabled"

--- a/recoco/apps/onboarding/templates/onboarding/fragments/form-user.html
+++ b/recoco/apps/onboarding/templates/onboarding/fragments/form-user.html
@@ -1,5 +1,7 @@
 {% load crispy_forms_tags %}
-<form id="{{ form.helper.form_id }}" method="post">
+<form id="{{ form.helper.form_id }}"
+      method="post"
+      x-on:input="isFormEdited = true">
     <input type="hidden"
            name="js_enabled"
            id="{{ form.helper.form_id }}_js_enabled"

--- a/recoco/frontend/src/js/components/DsrcFormValidator.js
+++ b/recoco/frontend/src/js/components/DsrcFormValidator.js
@@ -19,6 +19,8 @@ function DsrcFormValidator(formId, validationSchema, requestMethod = 'GET') {
     form: {},
     errors: [],
     schema: validationSchema,
+    isFormEdited: false,
+    canSubmit: true,
     submittedForm: requestMethod === 'POST',
     async init() {
       if (!this.schema) {
@@ -54,6 +56,8 @@ function DsrcFormValidator(formId, validationSchema, requestMethod = 'GET') {
       this.$nextTick(() => {
         // enable form validation for all submission types (click, keyboard, ...)
         document.getElementById(formId).addEventListener('submit', (event) => {
+          this.isFormEdited = false;
+          this.canSubmit = false;
           this.submittedForm = true;
           this.validate();
           if (Array.isArray(this.errors) && this.errors.length > 0) {


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Mise en place d'une logique pour bloquer la double soumission d'un formulaire.

Resolve #1126 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
