### PR TITLE
Problèmes de fichiers edl perdus si validation formulaire sans champ obligatoire

### DIFF
--- a/recoco/apps/survey/templates/survey/question_details.html
+++ b/recoco/apps/survey/templates/survey/question_details.html
@@ -124,7 +124,7 @@
                                   id="input-project-comment"
                                   name="{{ form.comment.name }}"
                                   placeholder="{{ question.comment_title }}"
-                                  {% if form.fields.comment.required %} required {% endif %}>
+                                  {% if form.fields.comment.required %}required{% endif %}>
                                   {{ form.comment.value|default:'' }}
                                 </textarea>
                         {% for error in form.comment.errors %}

--- a/recoco/apps/survey/templates/survey/question_details.html
+++ b/recoco/apps/survey/templates/survey/question_details.html
@@ -123,7 +123,10 @@
                         <textarea class="form-control {% if form.comment.errors %}is-invalid{% endif %} specific-height-100px"
                                   id="input-project-comment"
                                   name="{{ form.comment.name }}"
-                                  placeholder="{{ question.comment_title }}">{{ form.comment.value|default:'' }}</textarea>
+                                  placeholder="{{ question.comment_title }}"
+                                  {% if form.fields.comment.required %} required {% endif %}>
+                                  {{ form.comment.value|default:'' }}
+                                </textarea>
                         {% for error in form.comment.errors %}
                             <div class="text-danger text-end">{{ error }}</div>
                         {% endfor %}
@@ -168,9 +171,9 @@
                                 type="submit"
                                 data-test-id="button-submit-survey-questionset">
                             <svg class="d-inline-block bi fr-mr-1v"
-                                 width="16"
-                                 height="16"
-                                 fill="currentColor">
+                                width="16"
+                                height="16"
+                                fill="currentColor">
                                 <use xlink:href="{% static 'svg/bootstrap-icons.svg'  %}#check2-circle" />
                             </svg>
                             &nbsp;


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Résolution des problèmes de fichiers edl perdus si validation formulaire sans champ obligatoire rempli.
Les champs de texte (textarea) obligatoire empêche maintenant la validation du formulaire relatif à la question actuelle du questionnaire grâce à l'attribut html required.

resolve #1212 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
