### PR TITLE
[fix] Réparation de l'entête des dossiers à faible répondant

### DIFF
--- a/recoco/apps/crm/templates/crm/projects_low_reach.html
+++ b/recoco/apps/crm/templates/crm/projects_low_reach.html
@@ -15,13 +15,13 @@
 {% block content %}
     <div x-data="Crm" class="d-flex fr-px-0">
         {% include "crm/fragments/sidebar.html" with back_button=True map=True tools=True search=True %}
-        <div class="w-75 d-flex flex-column justify-content-start position-fixed left-25prct">
+        <div class="w-75 d-flex flex-column justify-content-start">
             <div class="d-flex justify-content-between align-items-center fr-px-3w fr-pt-3w">
                 <h2>Dossiers à faible répondant</h2>
                 <a href="{% url 'crm-projects-low-reach-csv' %}" class="btn btn-primary">Export CSV</a>
             </div>
             <table class="table table-striped">
-                <thead>
+                <thead class="sticky-header">
                     <tr>
                         <th>Nom</th>
                         <th>Conseillers</th>

--- a/recoco/apps/home/static/home/css/dsfr/custom-dsfr.scss
+++ b/recoco/apps/home/static/home/css/dsfr/custom-dsfr.scss
@@ -708,6 +708,7 @@ form > p {
   CRM - Custom styles
 \* ˍˍˍˍˍˍˍˍˍˍˍˍˍˍˍˍˍˍ */
 
-.left-25prct {
-  left: 25%;
+.sticky-header {
+  position: sticky;
+  top: 60px;
 }


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
L'entête des dossiers à faible répondant était en position fixe créant des bugs d'affichage selon certaines disposition.
L'entête est maintenant en position sticky pour la résolution du bug ci-dessus ainsi qu'une meilleure expérience utilisateur.rice.

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
