### PR TITLE
[feat] Cacher la partie complément sur la présentation sous condition

### DIFF
--- a/recoco/apps/projects/templates/projects/project/overview.html
+++ b/recoco/apps/projects/templates/projects/project/overview.html
@@ -121,7 +121,7 @@
                                             <!-- Contexte -->
                                             {% include "projects/project/fragments/information_card.html" with full_width=True padding_end=True padding_top=True full_height=True project=project title="Résumé du dossier" description=project.description updated_on=project.created_on card_user=project.submitted_by org_name=project.submitted_by.profile.organization.name data_test="context" %}
                                             <!-- Onboarding -->
-                                            {% if not onboarding_response %}
+                                            {% if not onboarding_response and site_config.onboarding_questions.count %}
                                                 {% include "projects/project/fragments/information_card.html" with full_width=True padding_end=True padding_top=True full_height=True project=project onboarding_information=True updated_on=project.created_on card_user=project.submitted_by org_name=project.submitted_by.profile.organization.name %}
                                             {% endif %}
                                             <!-- Old onboarding project  -->


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Sur la page de présentation d'un dossier, si aucune question de l'état des lieux ne fait partie de l'onboarding, la section "Complément" est cachée.
 
resolve #1234 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x]  La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
