### PR TITLE
fix: add Matomo heatmap plugin script in case Matomo instance does not bundle it in matomo.js

### DIFF
--- a/recoco/templates/default_site/matomo.html
+++ b/recoco/templates/default_site/matomo.html
@@ -12,6 +12,8 @@
     _paq.push(['setSiteId', '{{ matomo_site_id }}']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    var h = d.createElement('script');
+    h.async=true; h.src=u+'plugins/HeatmapSessionRecording/tracker.min.js'; s.parentNode.insertBefore(h,s);
   })();
 </script>
 {% else %}


### PR DESCRIPTION
Matomo instances should normally automatically bundle Heatmap plugin JS code with matomo.js.

On beta.gouv.fr, it seems that this feature has been disabled (probably because most websites do not use Heatmap plugin), which could be the reason Heatmap are not working at the moment.