### PR TITLE
Mots de passe complexes

### DIFF
--- a/recoco/apps/home/adapters.py
+++ b/recoco/apps/home/adapters.py
@@ -1,8 +1,11 @@
+import re
+
 from allauth.account import adapter as allauth_adapter
 from allauth.account import app_settings
 from allauth.account.utils import user_email, user_username
 from django.contrib.auth import models as auth_models
 from django.contrib.sites.shortcuts import get_current_site
+from django.core.exceptions import ValidationError
 from magicauth import adapters as magicauth_adapters
 
 from . import utils
@@ -34,6 +37,14 @@ class UVAccountAdapter(allauth_adapter.DefaultAccountAdapter):
         saved_user.profile.sites.add(get_current_site(request))
 
         return saved_user
+
+    def clean_password(self, password, user=None):
+        if re.match(r"^(?=.*?\d)(?=.*?[A-Z])(?=.*?[a-z])[A-Za-z\d]{8,}$", password):
+            return password
+        else:
+            raise ValidationError(
+                "Votre mot de passe doit comporter au moins 8 caractères, une majuscule et un chiffre."
+            )
 
 
 class UVMagicauthAdapter(magicauth_adapters.DefaultAccountAdapter):

--- a/recoco/apps/home/forms.py
+++ b/recoco/apps/home/forms.py
@@ -34,7 +34,7 @@ class UVSignupForm(SignupForm):
 
         self.fields[
             "password1"
-        ].label = "Définissez votre mot de passe (8 caractères minimum)"
+        ].label = "Définissez votre mot de passe (8 caractères minimum et au moins 1 majuscule et 1 chiffre)"
         self.fields["password1"].widget = forms.PasswordInput(
             attrs={"class": "fr-input fr-mt-2v fr-mb-4v"}
         )
@@ -65,7 +65,9 @@ class UVResetPasswordForm(ResetPasswordForm):
 class UVResetPasswordKeyForm(ResetPasswordKeyForm):
     def __init__(self, *args, **kwargs):
         super(UVResetPasswordKeyForm, self).__init__(*args, **kwargs)
-        self.fields["password1"].label = "Nouveau mot de passe (8 caractères minimum)"
+        self.fields[
+            "password1"
+        ].label = "Nouveau mot de passe (8 caractères minimum et au moins 1 majuscule et 1 chiffre)"
         self.fields["password1"].widget = forms.PasswordInput(
             attrs={"class": "fr-input fr-mt-2v fr-mb-4v"}
         )

--- a/recoco/apps/home/tests/test_views.py
+++ b/recoco/apps/home/tests/test_views.py
@@ -81,6 +81,80 @@ def test_get_current_site_sender_without_configuration(request):
 
 
 @pytest.mark.django_db
+def test_create_user_requires_8characters_password(client, request):
+    data = {
+        "first_name": "Test",
+        "last_name": "test",
+        "organization": "test",
+        "organization_position": "test",
+        "email": "kkkd@kdkdk.fr",
+        "phone_no": "0303003033",
+        "password1": "1234567",
+        "password2": "1234567",
+    }
+    response = client.post(reverse("account_signup"), data)
+    assert response.status_code == 200
+
+    assert auth_models.User.objects.filter(email=data["email"]).count() == 0
+
+
+@pytest.mark.django_db
+def test_create_user_requires_caps_in_password(client, request):
+    data = {
+        "first_name": "Test",
+        "last_name": "test",
+        "organization": "test",
+        "organization_position": "test",
+        "email": "kkkd@kdkdk.fr",
+        "phone_no": "0303003033",
+        "password1": "onlylowercase",
+        "password2": "onlylowercase",
+    }
+    response = client.post(reverse("account_signup"), data)
+    assert response.status_code == 200
+
+    assert auth_models.User.objects.filter(email=data["email"]).count() == 0
+
+
+@pytest.mark.django_db
+def test_create_user_requires_special_chars_in_password(client, request):
+    data = {
+        "first_name": "Test",
+        "last_name": "test",
+        "organization": "test",
+        "organization_position": "test",
+        "email": "kkkd@kdkdk.fr",
+        "phone_no": "0303003033",
+        "password1": "LowerCaseButNoSpecials",
+        "password2": "LowerCaseButNoSpecials",
+    }
+    response = client.post(reverse("account_signup"), data)
+    assert response.status_code == 200
+
+    assert auth_models.User.objects.filter(email=data["email"]).count() == 0
+
+
+@pytest.mark.django_db
+def test_create_user(client, request):
+    data = {
+        "first_name": "Test",
+        "last_name": "test",
+        "organization": "test",
+        "organization_position": "test",
+        "email": "kkkd@kdkdk.fr",
+        "phone_no": "0303003033",
+        "password1": "LowerCaseButNoSpecials12",
+        "password2": "LowerCaseButNoSpecials12",
+    }
+    response = client.post(reverse("account_signup"), data)
+    assert response.status_code == 302
+
+    user = auth_models.User.objects.get(email=data["email"])
+
+    assert len(user.profile.sites.all()) == 1
+
+
+@pytest.mark.django_db
 def test_create_user_assign_current_site_via_allauth(client, request):
     site = get_current_site(request)
     data = {

--- a/recoco/apps/onboarding/forms.py
+++ b/recoco/apps/onboarding/forms.py
@@ -164,7 +164,12 @@ class OnboardingSignupForm(DsrcBaseForm):
     def password_message_group(errors=None):
         return {
             "help_text": "Votre mot de passe doit contenir :",
-            "messages": [{"text": "8 caractères minimum", "type": "info"}],
+            "messages": [
+                {
+                    "text": "(8 caractères minimum et au moins 1 majuscule et 1 chiffre)",
+                    "type": "info",
+                }
+            ],
         }
 
     first_name = forms.CharField(label="Prénom *", initial="", required=True)
@@ -187,7 +192,7 @@ class OnboardingSignupForm(DsrcBaseForm):
     password = forms.CharField(
         label="Mot de passe *",
         required=True,
-        help_text="Votre mot de passe doit contenir 8 caractères minimum",
+        help_text="Votre mot de passe doit contenir 8 caractères minimum et au moins 1 majuscule et 1 chiffre",
         widget=forms.PasswordInput(
             attrs={"size": "sm", "message_group": password_message_group()}
         ),

--- a/recoco/frontend/src/js/utils/ajv/schema/ajv.schema.OnboardingSignupForm.js
+++ b/recoco/frontend/src/js/utils/ajv/schema/ajv.schema.OnboardingSignupForm.js
@@ -41,7 +41,7 @@ export const schemaOnboardingStep1SignupFormValidator = {
     },
     role: { $ref: '#/definitions/text' },
     email: { $ref: '#/definitions/email' },
-    password: { $ref: '#/definitions/passwordSoft' },
+    password: { $ref: '#/definitions/passwordNormal' },
     phone: { $ref: '#/definitions/phone' },
   },
   required: ['first_name', 'last_name', 'role', 'email', 'password', 'phone'],

--- a/recoco/frontend/src/js/utils/ajv/schema/ajv.schema.forms.js
+++ b/recoco/frontend/src/js/utils/ajv/schema/ajv.schema.forms.js
@@ -84,6 +84,26 @@ export const schemaFormInputs = {
       },
     ],
   },
+  passwordNormal: {
+    allOf: [
+      {
+        type: 'string',
+        format: 'password',
+        minLength: 8,
+        errorMessage: minLengthErrorMessage(8),
+      },
+      {
+        type: 'string',
+        pattern: '[0-9]{1}',
+        errorMessage: '1 chiffre minimum',
+      },
+      {
+        type: 'string',
+        pattern: '[A-Z]{1}',
+        errorMessage: '1 majuscule minimum',
+      },
+    ],
+  },
   postcode: {
     // TODO : adapt for French postcode validation
     allOf: [


### PR DESCRIPTION
Enforce using an uppercase letter, 8 characters and a number for signups.

Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [X] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Dans le cadre de l'homologation de sécurité, nous devons renforcer la complexité des mots de passe.
Cette PR oblige à utiliser une majuscule, une chiffre et au moins 8 caractères.

=> Liens vers des éléments de Github Issue, Trello, ...

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
