### PR TITLE
Retour de la vue carte avec une nouvelle carte et des filtres projets

### DIFF
--- a/recoco/apps/projects/templates/projects/project/fragments/navigation/display_select.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/navigation/display_select.html
@@ -15,7 +15,7 @@
                     <a href="{% url "projects-project-list-staff" %}">Tableau</a>
                 </label>
             </div>
-            <div class="fr-segmented__element">
+            {% comment %} <div class="fr-segmented__element">
                 <input value="list"
                        {% if url_name == 'projects-project-list-advisor' %}checked{% endif %}
                        type="radio"
@@ -25,7 +25,7 @@
                 <label class="fr-label" for="list-display">
                     <a href="{% url "projects-project-list-advisor" %}">Liste</a>
                 </label>
-            </div>
+            </div> {% endcomment %}
             <div class="fr-segmented__element">
                 <input value="map"
                        {% if url_name == 'projects-project-list-map' %}checked{% endif %}

--- a/recoco/apps/projects/templates/projects/project/fragments/personal_dashboard/personal_dashboard_map.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/personal_dashboard/personal_dashboard_map.html
@@ -2,10 +2,7 @@
 <div x-cloak
      class="fr-p-0 personal-dashboard-map-container"
      :class="{'is-small':mapIsSmall}">
-    <div class="h-100 w-100"
-         x-ref="map"
-         id="map"
-         class="personal-dashboard-map"></div>
+    <div class="h-100 w-100 personal-dashboard-map" x-ref="map" id="map"></div>
     <div class="map-increase-height-button" x-on:click="handleMapOpen">
         <svg :class="!mapIsSmall ? 'd-none' : 'd-block'"
              class="z-1"

--- a/recoco/apps/projects/templates/projects/project/fragments/tasks_inline_kanban/tasks_inline_kanban_filters.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/tasks_inline_kanban/tasks_inline_kanban_filters.html
@@ -1,0 +1,32 @@
+<div class="kanban-header topbar d-flex justify-content-between align-items-center fr-p-2v">
+    <div class="kanban-header__view-selector fs-5 fr-mr-6v">
+        {% include "projects/project/fragments/navigation/display_select.html" %}
+    </div>
+    <div x-data="Tutorial('time-filter-tutorial-on-kanban')"
+         class="kanban-header__middle-part">
+        <div class="kanban-header__searchbar position-relative">
+            {% include "projects/project/fragments/search_bar.html" with action_search="onSearch" x_model="searchText" placeholder="Rechercher commune, #tag, nom du dossier..." %}
+        </div>
+        <div class="kanban-header__lastactivity-filter fr-select-group d-flex fr-m-0 fr-mr-6v align-items-center"
+             id="kanban-time-filter">
+            <label class="fr-label no-wrap fr-mr-1v"
+                   for="select-filter-project-duration">Dossiers actifs depuis :</label>
+            <select class="fr-select fr-m-0"
+                    name="select-filter-project-duration"
+                    x-ref="selectFilterProjectDuration"
+                    x-model="filterProjectLastActivity"
+                    @change='onLastActivityChange'>
+                <option value="30">1 mois</option>
+                <option value="90">3 mois</option>
+                <option value="180">6 mois</option>
+                <option value="365">1 an</option>
+                <option value="1460">Plus</option>
+            </select>
+        </div>
+        <div class="kanban-header__my-projects-toggle">
+            {% include "projects/project/fragments/only_my_projects_toggle.html" %}
+        </div>
+        <div class="kanban-header__region-filter">
+            {% include "projects/project/fragments/departments_selector.html" with label="Projets de mon territoire" filter_by_regions=True zone_objects="regions" select_all=True %}
+        </div>
+    </div>

--- a/recoco/apps/projects/templates/projects/project/list-kanban.html
+++ b/recoco/apps/projects/templates/projects/project/list-kanban.html
@@ -42,10 +42,10 @@
                 <span class="visually-hidden">Loading...</span>
             </div>
         </div>
-        <div class="kanban-header topbar d-flex justify-content-end align-items-center fr-p-2v">
-            {% comment %} <div class="kanban-header__view-selector fs-5 fr-mr-6v">
+        <div class="kanban-header topbar d-flex justify-content-between align-items-center fr-p-2v">
+            <div class="kanban-header__view-selector fs-5 fr-mr-6v">
                 {% include "projects/project/fragments/navigation/display_select.html" %}
-            </div> {% endcomment %}
+            </div>
             <div x-data="Tutorial('time-filter-tutorial-on-kanban')"
                  class="kanban-header__middle-part">
                 <div class="kanban-header__searchbar position-relative">

--- a/recoco/apps/projects/templates/projects/project/list-kanban.html
+++ b/recoco/apps/projects/templates/projects/project/list-kanban.html
@@ -42,39 +42,8 @@
                 <span class="visually-hidden">Loading...</span>
             </div>
         </div>
-        <div class="kanban-header topbar d-flex justify-content-between align-items-center fr-p-2v">
-            <div class="kanban-header__view-selector fs-5 fr-mr-6v">
-                {% include "projects/project/fragments/navigation/display_select.html" %}
-            </div>
-            <div x-data="Tutorial('time-filter-tutorial-on-kanban')"
-                 class="kanban-header__middle-part">
-                <div class="kanban-header__searchbar position-relative">
-                    {% include "projects/project/fragments/search_bar.html" with action_search="onSearch" x_model="searchText" placeholder="Rechercher commune, #tag, nom du dossier..." %}
-                </div>
-                <div class="kanban-header__lastactivity-filter fr-select-group d-flex fr-m-0 fr-mr-6v align-items-center"
-                     id="kanban-time-filter">
-                    <label class="fr-label no-wrap fr-mr-1v"
-                           for="select-filter-project-duration">Dossiers actifs depuis :</label>
-                    <select class="fr-select fr-m-0"
-                            name="select-filter-project-duration"
-                            x-ref="selectFilterProjectDuration"
-                            x-model="filterProjectLastActivity"
-                            @change='onLastActivityChange'>
-                        <option value="30">1 mois</option>
-                        <option value="90">3 mois</option>
-                        <option value="180">6 mois</option>
-                        <option value="365">1 an</option>
-                        <option value="1460">Plus</option>
-                    </select>
-                </div>
-                <div class="kanban-header__my-projects-toggle">
-                    {% include "projects/project/fragments/only_my_projects_toggle.html" %}
-                </div>
-                <div class="kanban-header__region-filter">
-                    {% include "projects/project/fragments/departments_selector.html" with label="Projets de mon territoire" filter_by_regions=True zone_objects="regions" select_all=True %}
-                </div>
-            </div>
-            <div class="kanban-header__toolbar">{% include "projects/project/fragments/list-toolbars.html" %}</div>
+        <div>
+            {% include "projects/project/fragments/tasks_inline_kanban/tasks_inline_kanban_filters.html" %}
         </div>
         <template x-if="isViewInitialized && projectList.length == 0">
             <div class="fr-notice fr-notice--info fr-my-8w">

--- a/recoco/apps/projects/templates/projects/project/list-map.html
+++ b/recoco/apps/projects/templates/projects/project/list-map.html
@@ -17,62 +17,63 @@
     <link href="{% sass_src 'projects/css/segmented_ctrl.scss' %}"
           rel="stylesheet"
           type="text/css">
-          <link href="{% sass_src 'projects/css/kanban.scss' %}"
+    <link href="{% sass_src 'projects/css/kanban.scss' %}"
           rel="stylesheet"
           type="text/css">
 {% endblock css %}
 {% block project_list_content %}
     {{ departments|json_script:"departmentsArray" }}
     {{ regions|json_script:"regionsArray" }}
-<div class="col-12 fr-mx-auto font-marianne">
-    <div x-data="PersonalAdvisorDashboard({{ request.site.id }}, departmentsArray, regionsArray)"
-         x-init='getData("{{ request.user }}");'
-         @selected-departments="saveSelectedDepartment($event)">
-         <div class="kanban-header topbar d-flex justify-content-between align-items-center fr-p-2v">
-            <div class="kanban-header__view-selector fs-5 fr-mr-6v">
-                {% include "projects/project/fragments/navigation/display_select.html" %}
+    <div class="col-12 fr-mx-auto font-marianne">
+        <div x-data="PersonalAdvisorDashboard({{ request.site.id }}, departmentsArray, regionsArray)"
+             x-init='getData("{{ request.user }}");'
+             @selected-departments="saveSelectedDepartment($event)">
+            <div class="kanban-header topbar d-flex justify-content-between align-items-center fr-p-2v">
+                <div class="kanban-header__view-selector fs-5 fr-mr-6v">
+                    {% include "projects/project/fragments/navigation/display_select.html" %}
+                </div>
+                <div x-data="Tutorial('time-filter-tutorial-on-kanban')"
+                     class="kanban-header__middle-part">
+                    <div class="kanban-header__searchbar position-relative">
+                        {% include "projects/project/fragments/search_bar.html" with action_search="onSearch" x_model="searchText" placeholder="Rechercher commune, #tag, nom du dossier..." %}
+                    </div>
+                    <div class="kanban-header__lastactivity-filter fr-select-group d-flex fr-m-0 fr-mr-6v align-items-center"
+                         id="kanban-time-filter">
+                        <label class="fr-label no-wrap fr-mr-1v"
+                               for="select-filter-project-duration">Dossiers actifs depuis :</label>
+                        <select class="fr-select fr-m-0"
+                                name="select-filter-project-duration"
+                                x-ref="selectFilterProjectDuration"
+                                x-model="filterProjectLastActivity"
+                                @change='onLastActivityChange'>
+                            <option value="30">1 mois</option>
+                            <option value="90">3 mois</option>
+                            <option value="180">6 mois</option>
+                            <option value="365">1 an</option>
+                            <option value="1460">Plus</option>
+                        </select>
+                    </div>
+                    <div class="kanban-header__my-projects-toggle">
+                        {% include "projects/project/fragments/only_my_projects_toggle.html" %}
+                    </div>
+                    <div class="kanban-header__region-filter">
+                        {% include "projects/project/fragments/departments_selector.html" with label="Projets de mon territoire" filter_by_regions=True zone_objects="regions" select_all=True %}
+                    </div>
+                </div>
+                <div class="kanban-header__toolbar">{% include "projects/project/fragments/list-toolbars.html" %}</div>
             </div>
-            <div x-data="Tutorial('time-filter-tutorial-on-kanban')"
-                 class="kanban-header__middle-part">
-                <div class="kanban-header__searchbar position-relative">
-                    {% include "projects/project/fragments/search_bar.html" with action_search="onSearch" x_model="searchText" placeholder="Rechercher commune, #tag, nom du dossier..." %}
-                </div>
-                <div class="kanban-header__lastactivity-filter fr-select-group d-flex fr-m-0 fr-mr-6v align-items-center"
-                     id="kanban-time-filter">
-                    <label class="fr-label no-wrap fr-mr-1v"
-                           for="select-filter-project-duration">Dossiers actifs depuis :</label>
-                    <select class="fr-select fr-m-0"
-                            name="select-filter-project-duration"
-                            x-ref="selectFilterProjectDuration"
-                            x-model="filterProjectLastActivity"
-                            @change='onLastActivityChange'>
-                        <option value="30">1 mois</option>
-                        <option value="90">3 mois</option>
-                        <option value="180">6 mois</option>
-                        <option value="365">1 an</option>
-                        <option value="1460">Plus</option>
-                    </select>
-                </div>
-                <div class="kanban-header__my-projects-toggle">
-                    {% include "projects/project/fragments/only_my_projects_toggle.html" %}
-                </div>
-                <div class="kanban-header__region-filter">
-                    {% include "projects/project/fragments/departments_selector.html" with label="Projets de mon territoire" filter_by_regions=True zone_objects="regions" select_all=True %}
+            <div class="d-flex align-items-start fr-pt-3w">
+                <div class="personal-dashboard-container-inner w-100">
+                    {% include "projects/project/fragments/personal_dashboard/personal_dashboard_map.html" %}
                 </div>
             </div>
-            <div class="kanban-header__toolbar">{% include "projects/project/fragments/list-toolbars.html" %}</div>
-        </div>
-        <div class="d-flex align-items-start fr-pt-3w">
-            <div class="personal-dashboard-container-inner w-100">
-                {% include "projects/project/fragments/personal_dashboard/personal_dashboard_map.html" %}
+            <div>
+                <span class="fr-mb-2w">Légende :</span>
+                <ul class="fr-ml-2w">
+                    <li>jaune : dossiers non consultés</li>
+                    <li>noir : dossiers déjà consultés</li>
+                </ul>
             </div>
-        </div>
-        <div>
-            <span class="fr-mb-2w">Légende :</span>
-            <ul class="fr-ml-2w">
-                <li> jaune : dossiers non consultés </li>
-                <li> noir : dossiers déjà consultés </li>
-            </ul>
         </div>
     </div>
 {% endblock project_list_content %}

--- a/recoco/apps/projects/templates/projects/project/list-map.html
+++ b/recoco/apps/projects/templates/projects/project/list-map.html
@@ -1,55 +1,83 @@
 {% extends "projects/project/list.html" %}
+{% load django_vite %}
 {% load static %}
+{% load sass_tags %}
 {% block title %}
     Carte des dossiers {{ block.super }}
 {% endblock title %}
 {% block og_title %}
     Carte des dossiers {{ block.super }}
 {% endblock og_title %}
+{% block js %}
+    {% vite_asset 'js/apps/advisorDashboard.js' %}
+    {% vite_asset 'js/apps/tutorial.js' %}
+    {% vite_asset 'js/apps/boardProjects.js' %}
+{% endblock js %}
+{% block css %}
+    <link href="{% sass_src 'projects/css/segmented_ctrl.scss' %}"
+          rel="stylesheet"
+          type="text/css">
+          <link href="{% sass_src 'projects/css/kanban.scss' %}"
+          rel="stylesheet"
+          type="text/css">
+{% endblock css %}
 {% block project_list_content %}
-    <div x-data="Map">
-        <div class="topbar d-flex justify-content-between fr-p-2v">
-            <span class="fs-5 flex-grow-1">
-                {% comment %} {% include "projects/project/fragments/navigation/display_select.html" %} {% endcomment %}
-                {% if project_moderator %}
-                    <svg class="fr-ml-2v align-middle bi"
-                         width="24px"
-                         height="24px"
-                         fill="currentColor">
-                        <use xlink:href="{% static 'svg/bootstrap-icons.svg'  %}#binoculars" />
-                    </svg>
-                    <span class="align-middle">
-                        {% with draft_projects.count as draft_projects_count %}
-                            {% if draft_projects_count > 0 %}
-                                <a href="#draft-projects">{{ draft_projects_count }} dossier{{ draft_projects_count|pluralize }}</a> en attente d'acceptation
-                            {% endif %}
-                        {% endwith %}
-                    </span>
-                    -
-                {% endif %}
-                {% if unread_notifications.count %}
-                    <div class="d-inline">
-                        <svg class="align-middle text-danger bi"
-                             width="16px"
-                             height="16px"
-                             fill="currentColor">
-                            <use xlink:href="{% static 'svg/bootstrap-icons.svg'  %}#bell-fill" />
-                        </svg>
-                        <span class="badge live_notify_badge bg-secondary">{{ unread_notifications.count }}</span>
-                    </div>
-                {% endif %}
-            </span>
-            <div x-show="isBusy"
-                 x-transition
-                 class="position-absolute w-100 text-center">
-                <div class="spinner-border" role="status">
-                    <span class="visually-hidden">Loading...</span>
+    {{ departments|json_script:"departmentsArray" }}
+    {{ regions|json_script:"regionsArray" }}
+<div x-data="KanbanProjects({{ request.site.id }}, departmentsArray, regionsArray )"
+     @selected-departments="saveSelectedDepartment($event)"
+     class="col-12 fr-mx-auto font-marianne">
+    <div x-data="PersonalAdvisorDashboard({{ request.site.id }})"
+         x-init='getData("{{ request.user }}");'
+         @selected-departments="regionsFilterResponse($event)">
+         <div class="kanban-header topbar d-flex justify-content-between align-items-center fr-p-2v">
+            <div class="kanban-header__view-selector fs-5 fr-mr-6v">
+                {% include "projects/project/fragments/navigation/display_select.html" %}
+            </div>
+            <div x-data="Tutorial('time-filter-tutorial-on-kanban')"
+                 class="kanban-header__middle-part">
+                <div class="kanban-header__searchbar position-relative">
+                    {% include "projects/project/fragments/search_bar.html" with action_search="onSearch" x_model="searchText" placeholder="Rechercher commune, #tag, nom du dossier..." %}
+                </div>
+                <div class="kanban-header__lastactivity-filter fr-select-group d-flex fr-m-0 fr-mr-6v align-items-center"
+                     id="kanban-time-filter">
+                    <label class="fr-label no-wrap fr-mr-1v"
+                           for="select-filter-project-duration">Dossiers actifs depuis :</label>
+                    <select class="fr-select fr-m-0"
+                            name="select-filter-project-duration"
+                            x-ref="selectFilterProjectDuration"
+                            x-model="filterProjectLastActivity"
+                            @change='onLastActivityChange'>
+                        <option value="30">1 mois</option>
+                        <option value="90">3 mois</option>
+                        <option value="180">6 mois</option>
+                        <option value="365">1 an</option>
+                        <option value="1460">Plus</option>
+                    </select>
+                </div>
+                <div class="kanban-header__my-projects-toggle">
+                    {% include "projects/project/fragments/only_my_projects_toggle.html" %}
+                </div>
+                <div class="kanban-header__region-filter">
+                    {% include "projects/project/fragments/departments_selector.html" with label="Projets de mon territoire" filter_by_regions=True zone_objects="regions" select_all=True %}
                 </div>
             </div>
-            {% include "projects/project/fragments/list-toolbars.html" %}
+            <div class="kanban-header__toolbar">{% include "projects/project/fragments/list-toolbars.html" %}</div>
         </div>
-        <div x-cloak class="fr-p-0 fr-pt-3w">
-            <div x-ref="map" id="map"></div>
+        <div class="d-flex align-items-start fr-pt-3w">
+            <div class="personal-dashboard-container-inner w-100">
+                {% include "projects/project/fragments/personal_dashboard/personal_dashboard_map.html" %}
+            </div>
+        </div>
+        <div>
+            <span class="fr-mb-2w">Légende :</span>
+            <ul class="fr-ml-2w">
+                <li> jaune : dossiers non consultés </li>
+                <li> noir : dossiers déjà consultés </li>
+            </ul>
         </div>
     </div>
 {% endblock project_list_content %}
+
+
+{% comment %}  {% endcomment %}

--- a/recoco/apps/projects/templates/projects/project/list-map.html
+++ b/recoco/apps/projects/templates/projects/project/list-map.html
@@ -24,12 +24,10 @@
 {% block project_list_content %}
     {{ departments|json_script:"departmentsArray" }}
     {{ regions|json_script:"regionsArray" }}
-<div x-data="KanbanProjects({{ request.site.id }}, departmentsArray, regionsArray )"
-     @selected-departments="saveSelectedDepartment($event)"
-     class="col-12 fr-mx-auto font-marianne">
-    <div x-data="PersonalAdvisorDashboard({{ request.site.id }})"
+<div class="col-12 fr-mx-auto font-marianne">
+    <div x-data="PersonalAdvisorDashboard({{ request.site.id }}, departmentsArray, regionsArray)"
          x-init='getData("{{ request.user }}");'
-         @selected-departments="regionsFilterResponse($event)">
+         @selected-departments="saveSelectedDepartment($event)">
          <div class="kanban-header topbar d-flex justify-content-between align-items-center fr-p-2v">
             <div class="kanban-header__view-selector fs-5 fr-mr-6v">
                 {% include "projects/project/fragments/navigation/display_select.html" %}

--- a/recoco/apps/projects/templates/projects/project/list-map.html
+++ b/recoco/apps/projects/templates/projects/project/list-map.html
@@ -28,44 +28,8 @@
         <div x-data="PersonalAdvisorDashboard({{ request.site.id }}, departmentsArray, regionsArray)"
              x-init='getData("{{ request.user }}");'
              @selected-departments="saveSelectedDepartment($event)">
-            <div class="kanban-header topbar d-flex justify-content-between align-items-center fr-p-2v">
-                <div class="kanban-header__view-selector fs-5 fr-mr-6v">
-                    {% include "projects/project/fragments/navigation/display_select.html" %}
-                </div>
-                <div x-data="Tutorial('time-filter-tutorial-on-kanban')"
-                     class="kanban-header__middle-part">
-                    <div class="kanban-header__searchbar position-relative">
-                        {% include "projects/project/fragments/search_bar.html" with action_search="onSearch" x_model="searchText" placeholder="Rechercher commune, #tag, nom du dossier..." %}
-                    </div>
-                    <div class="kanban-header__lastactivity-filter fr-select-group d-flex fr-m-0 fr-mr-6v align-items-center"
-                         id="kanban-time-filter">
-                        <label class="fr-label no-wrap fr-mr-1v"
-                               for="select-filter-project-duration">Dossiers actifs depuis :</label>
-                        <select class="fr-select fr-m-0"
-                                name="select-filter-project-duration"
-                                x-ref="selectFilterProjectDuration"
-                                x-model="filterProjectLastActivity"
-                                @change='onLastActivityChange'>
-                            <option value="30">1 mois</option>
-                            <option value="90">3 mois</option>
-                            <option value="180">6 mois</option>
-                            <option value="365">1 an</option>
-                            <option value="1460">Plus</option>
-                        </select>
-                    </div>
-                    <div class="kanban-header__my-projects-toggle">
-                        {% include "projects/project/fragments/only_my_projects_toggle.html" %}
-                    </div>
-                    <div class="kanban-header__region-filter">
-                        {% include "projects/project/fragments/departments_selector.html" with label="Projets de mon territoire" filter_by_regions=True zone_objects="regions" select_all=True %}
-                    </div>
-                </div>
+                {% include "projects/project/fragments/tasks_inline_kanban/tasks_inline_kanban_filters.html" %}
                 <div class="kanban-header__toolbar">{% include "projects/project/fragments/list-toolbars.html" %}</div>
-            </div>
-            <div class="d-flex align-items-start fr-pt-3w">
-                <div class="personal-dashboard-container-inner w-100">
-                    {% include "projects/project/fragments/personal_dashboard/personal_dashboard_map.html" %}
-                </div>
             </div>
             <div>
                 <span class="fr-mb-2w">Légende :</span>
@@ -73,6 +37,11 @@
                     <li>jaune : dossiers non consultés</li>
                     <li>noir : dossiers déjà consultés</li>
                 </ul>
+            </div>
+            <div class="d-flex align-items-start fr-pt-3w">
+                <div class="personal-dashboard-container-inner w-100">
+                    {% include "projects/project/fragments/personal_dashboard/personal_dashboard_map.html" %}
+                </div>
             </div>
         </div>
     </div>

--- a/recoco/apps/projects/templates/projects/project/list-map.html
+++ b/recoco/apps/projects/templates/projects/project/list-map.html
@@ -76,6 +76,3 @@
         </div>
     </div>
 {% endblock project_list_content %}
-
-
-{% comment %}  {% endcomment %}

--- a/recoco/apps/projects/views/__init__.py
+++ b/recoco/apps/projects/views/__init__.py
@@ -473,7 +473,33 @@ def project_maplist(request):
         .order_by("-timestamp")[:100]
     )
 
-    return render(request, "projects/project/list-map.html", locals())
+    # Provide departments/regions for filters on the map list, similar to staff view
+    department_queryset = (
+        geomatics_models.Department.objects.filter(
+            code__in=(
+                models.Project.on_site.for_user(request.user)
+                .order_by("-created_on", "-updated_on")
+                .prefetch_related("commune__department")
+                .values_list("commune__department", flat=True)
+            )
+        )
+        | request.user.profile.departments.all()
+    ).distinct()
+
+    region_queryset = (
+        geomatics_models.Region.objects.filter(departments__in=department_queryset)
+        .prefetch_related("departments")
+        .distinct()
+        .order_by("name")
+    )
+
+    context = {
+        "departments": list(DepartmentSerializer(department_queryset, many=True).data),
+        "regions": list(RegionSerializer(region_queryset, many=True).data),
+        **locals(),
+    }
+
+    return render(request, "projects/project/list-map.html", context)
 
 
 # ----

--- a/recoco/frontend/src/css/personalAdvisorDashboard.css
+++ b/recoco/frontend/src/css/personalAdvisorDashboard.css
@@ -12,10 +12,10 @@ main {
   position: relative;
   background-color: #e6e6e6;
   background: #f6f6f6;
-  border-width: 1px 1px 0px 0px;
+  border-width: 1px 1px 1px 1px;
   border-style: solid;
   border-color: #e5e5e5;
-  border-radius: 0px 4px 0px 0px;
+  border-radius: 4px 4px 4px 4px;
 }
 
 .positioning-dropdown {
@@ -72,7 +72,7 @@ main {
 
 .personal-dashboard-map-container {
   position: relative;
-  height: 40vh;
+  height: 70vh;
   width: 100%;
   z-index: 100;
 

--- a/recoco/frontend/src/js/components/KanbanProjects.js
+++ b/recoco/frontend/src/js/components/KanbanProjects.js
@@ -21,9 +21,9 @@ Alpine.data('KanbanProjects', function (currentSiteId, departments, regions) {
       searchDepartment: [],
       lastActivity: localStorage.getItem('lastActivity') ?? '30',
     },
-    filterProjectLastActivity: localStorage.getItem('lastActivity') ?? '30',
     searchText: '',
-    selectedDepartment: null,
+    filterProjectLastActivity: localStorage.getItem('lastActivity') ?? '30',
+    selectedDepartment: null, // is it used ?
     departments: JSON.parse(departments.textContent),
     regions: JSON.parse(regions.textContent),
     territorySelectAll: true,


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Réaffichage du sélecteur de vue sans la vue liste.
Changement de carte dans la vue carte par celle de la vue liste.
Ajout de la barre de filtre de la vue kanban des projets.
Adaptation des filtres à la vue carte et de la carte au changement d'affichage des pins des projets en fonction des filtres.

Environnement de pré-prod souhaité pour s'assurer du bon fonctionnement de la carte et des filtres.
J'ai eu un bug en dév, je pensais que cela venait de mon environnement local, mais j'ai retrouvé le bug dans sentry.
Il est et n'est pas lié à ma PR. Cependant, cela peut entrainer des problèmes d'affichage de la carte.

Resolve #1418 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [x] Je souhaite un déploiement en préproduction
