### PR TITLE
fix(old-advisor-view): Proposition de redirection vers le kanban du staff (solution temporaire ?)

### DIFF
--- a/recoco/apps/projects/views/__init__.py
+++ b/recoco/apps/projects/views/__init__.py
@@ -376,39 +376,9 @@ def project_list(request):
 @login_required
 @ensure_csrf_cookie
 @never_cache
-def project_list_for_advisor(request):
+def project_list_for_advisor():
     """Return the projects for the advisor"""
-    if not (
-        check_if_advisor(request.user, request.site)
-        or can_administrate_project(project=None, user=request.user)
-    ):
-        raise PermissionDenied("Vous n'avez pas le droit d'accéder à ceci.")
-
-    # unread_notifications = notifications_models.Notification.on_site.unread().filter(
-    #    recipient=request.user, public=True
-    # )
-
-    mark_general_notifications_as_seen(request.user)
-
-    project_ct = ContentType.objects.get_for_model(models.Project)
-    user_project_pks = list(
-        request.user.project_states.filter(
-            project__switchtenders=request.user
-        ).values_list("project__pk", flat=True)
-    )
-
-    action_stream = (
-        request.user.notifications.filter(
-            target_content_type=project_ct,
-            target_object_id__in=user_project_pks,
-        )
-        .prefetch_related("actor__profile__organization")
-        .prefetch_related("action_object")
-        .prefetch_related("target")
-        .order_by("-timestamp")[:20]
-    )
-
-    return render(request, "projects/project/personal_advisor_dashboard.html", locals())
+    return redirect("projects-project-list-staff")
 
 
 @login_required


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Permets de limiter les levées d'erreur dans Sentry en attendant d'avoir tranché sur le fait de supprimer définitivement cette vue conseiller.

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
