### PR TITLE
[fix] ajout d'un message d'erreur si l'on tente de dupliquer une organisation

### DIFF
--- a/recoco/frontend/src/js/components/FeatureAddContact/CreateOrganizationModal.js
+++ b/recoco/frontend/src/js/components/FeatureAddContact/CreateOrganizationModal.js
@@ -18,6 +18,7 @@ Alpine.data('CreateOrganizationModal', (data = null) => {
     departments: null,
     selectedDepartments: null,
     isFormInEditMode: false,
+    isOrgaAlreadyExistingOnOtherPortal: false,
     organization: {
       name: '',
       group: null,
@@ -131,6 +132,13 @@ Alpine.data('CreateOrganizationModal', (data = null) => {
             }
           })
           .catch((error) => {
+            if (
+              error.response.data.name &&
+              error.response.data.name[0] ===
+                'Un objet organization avec ce champ Nom existe déjà.'
+            ) {
+              this.isOrgaAlreadyExistingOnOtherPortal = true;
+            }
             throw new Error('Error while creating organization ', error);
           });
       }

--- a/recoco/static/css/tools/contact/create-contact-modal.scss
+++ b/recoco/static/css/tools/contact/create-contact-modal.scss
@@ -26,7 +26,7 @@
 }
 
 .color-important {
-  color: var(--color-important, #ff0000);
+  color: var(--color-important, #ff0000) !important;
 }
 // .red-text {
 //   color: var(--color-important, #ff0000);

--- a/recoco/templates/default_site/tools/contacts/create_organization_modal.html
+++ b/recoco/templates/default_site/tools/contacts/create_organization_modal.html
@@ -28,6 +28,9 @@
                 <template x-if="formState.isSubmitted && !formState.fields.isOrgaName">
                     <p class="modal-create-organization__label-info color-important">Le nom de votre organisation est obligatoire *</p>
                 </template>
+                <template x-if="isOrgaAlreadyExistingOnOtherPortal">
+                    <p class="modal-create-organization__label-info color-important">Cette organisation existe déjà dans la base de données d'un autre portail. Essayez de changer le nom de votre organisation ou de contacter les administrateurs.</p>
+                </template>
                 <input type="text"
                        class="fr-input"
                        :class="{'fr-input--error': formState.isSubmitted && !formState.fields.isOrgaName}"


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

Ajout d'un message d'erreur lors d'une tentative de création d'une organisation existante sur un autre portail dans la modale de création d'une organisation.

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
