### PR TITLE
Ré-affichage du bouton d'acceptation d'une invitation d'un projet

### DIFF
--- a/recoco/apps/invites/templates/invites/fragments/invite_form.html
+++ b/recoco/apps/invites/templates/invites/fragments/invite_form.html
@@ -112,9 +112,9 @@
                         </div>
                     </div>
                 </div>
+                {% endif %}
                 <ul class="fr-btns-group fr-btns-group--inline-sm fr-mt-4w">
                     <li class="w-50">
-                        {% comment %} TODO: add url/action from backend {% endcomment %}
                         <button class="fr-btn fr-btn--tertiary-no-outline w-100 align-self-center"
                                 type="submit"
                                 form="refuse-form">Refuser</button>
@@ -123,7 +123,6 @@
                         <button class="fr-btn fr-btn--primary w-100 align-self-center" type="submit">Rejoindre le dossier</button>
                     </li>
                 </ul>
-            {% endif %}
         </form>
         <form action="{% url 'invites-invite-refuse' invite.pk %}"
               method="post"


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Les boutons accepter et refuser une invitation à un projet sont maintenant visibles pour tous.tes les utilisateurs.rices y compris les personnes qui ont déjà un compte.

Je pense que ce bug a entrainé l'incompréhension de la bannière "n'a pas rejoint le projet" car les invités pensaient avoir accceptés alors qu'ils ne pouvaient pas.

Resolve #1422

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
