### PR TITLE
Correction message d'erreur si aucun département sélectionné.

### DIFF
--- a/recoco/apps/home/forms.py
+++ b/recoco/apps/home/forms.py
@@ -152,7 +152,7 @@ class AdvisorAccessRequestForm(forms.Form):
         cleaned_data = super().clean()
         advisor_access_type = cleaned_data.get("advisor_access_type")
         departments = cleaned_data.get("departments")
-        if advisor_access_type == "Regional" and len(departments) == 0:
+        if advisor_access_type == "Regional" and not departments:
             self.add_error(
                 "departments", "Merci de sélectionner au moins un département."
             )


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Correction des conditions d'affichage de l'erreur dans la demande d'accès de compte conseiller.
Si l'on sélectionne le radio button "Un ou plusieurs départements" mais aucun département, une erreur est levée.

Resolve #1451

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
