### PR TITLE
Hotfix : impossible de modifier une organisation sans groupement national

### DIFF
--- a/recoco/frontend/src/js/components/FeatureAddContact/CreateOrganizationModal.js
+++ b/recoco/frontend/src/js/components/FeatureAddContact/CreateOrganizationModal.js
@@ -157,7 +157,9 @@ Alpine.data('CreateOrganizationModal', (data = null) => {
           this.formState.fields.isOrgaName) ||
         (!this.formState.fields.isGroupNat && this.formState.fields.isOrgaName)
       ) {
-        this.organization.group = this.organization.group.id;
+        if(this.organization.group){
+          this.organization.group = this.organization.group.id;
+        }
         api
           .patch(getOrganizationById(this.organization.id), this.organization)
           .then((response) => {


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Résolution du bug empêchant de modifier une organisation sans groupement national sans ajouter un groupement national.

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
