### PR TITLE
fix(addressbook): #1452 ensure orga creation and update uses given org_group

### DIFF
--- a/recoco/apps/addressbook/rest.py
+++ b/recoco/apps/addressbook/rest.py
@@ -33,9 +33,7 @@ class OrganizationViewSet(ModelViewSet):
     search_min_rank = 0.05
 
     def get_queryset(self):
-        return Organization.on_site.with_contacts_only().prefetch_related(
-            "departments__region"
-        )
+        return Organization.on_site.all().prefetch_related("departments__region")
 
     def get_serializer_class(self):
         match self.action:

--- a/recoco/apps/addressbook/signals.py
+++ b/recoco/apps/addressbook/signals.py
@@ -11,7 +11,7 @@ from .models import Organization, OrganizationGroup
 def create_organisation_national_group(
     sender: Any, instance: Organization, created: bool, **kwargs
 ):
-    if not created or instance.has_departments:
+    if not created or instance.has_departments or instance.group is not None:
         return
     with transaction.atomic():
         group, _ = OrganizationGroup.objects.get_or_create(name=instance.name)

--- a/recoco/apps/addressbook/tests/test_rest_organization.py
+++ b/recoco/apps/addressbook/tests/test_rest_organization.py
@@ -2,7 +2,7 @@ import pytest
 from django.urls import reverse
 from model_bakery import baker
 
-from ..models import Contact, Organization
+from ..models import Contact, Organization, OrganizationGroup
 
 
 @pytest.fixture
@@ -49,3 +49,25 @@ def test_anonymous_can_read_organization_but_not_update(api_client, acme_organiz
 
     response = api_client.delete(url, data={})
     assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_create_use_given_group(api_client, staff_user):
+    group = baker.make(OrganizationGroup)
+    url = reverse("api-addressbook-organization-list")
+
+    api_client.force_authenticate(staff_user)
+    response = api_client.post(url, {"group": group.id, "name": "orga_name"})
+    assert response.data["group"] == group.id
+
+
+@pytest.mark.django_db
+def test_update_use_given_group(api_client, staff_user, current_site):
+    group = baker.make(OrganizationGroup)
+    orga = baker.make(Organization, sites=[current_site])
+    url = reverse("api-addressbook-organization-detail", args=[orga.id])
+
+    api_client.force_authenticate(staff_user)
+    response = api_client.patch(url, {"group": group.id, "name": "orga_name"})
+    print(response.data)
+    assert response.data["group"] == group.id

--- a/recoco/frontend/src/js/components/FeatureAddContact/CreateOrganizationModal.js
+++ b/recoco/frontend/src/js/components/FeatureAddContact/CreateOrganizationModal.js
@@ -157,7 +157,6 @@ Alpine.data('CreateOrganizationModal', (data = null) => {
           this.formState.fields.isOrgaName) ||
         (!this.formState.fields.isGroupNat && this.formState.fields.isOrgaName)
       ) {
-        this.organization.group = this.organization.group.id;
         api
           .patch(getOrganizationById(this.organization.id), this.organization)
           .then((response) => {


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
en front : 
- corrige la prise en compte de l'id du regroupement national
en back
- ne crée pas de regroupement ad hoc si un est mentionné
- change le queryset d'organisation pour renvoyer les orgas sans contact. **A vérifier** je ne sais pas si je ne manque pas un contexte métier
- ajoute des tests pour la création/màj d'organisation

closes #1452

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
