### PR TITLE
Correction affichage sélecteur kanban / map

### DIFF
--- a/recoco/apps/projects/templates/projects/project/fragments/navigation/display_select.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/navigation/display_select.html
@@ -6,13 +6,13 @@
         <div class="fr-segmented__elements">
             <div class="fr-segmented__element">
                 <input value="table"
-                       {% if url_name == 'projects-project-list-staff' %}checked{% endif %}
+                       {% if url_name == 'projects-project-list' %}checked{% endif %}
                        type="radio"
                        id="table-display"
                        name="display-select-radio"
                        @click="window.location.href='{% url "projects-project-list-staff" %}'">
                 <label class="fr-label" for="table-display">
-                    <a href="{% url "projects-project-list-staff" %}">Tableau</a>
+                    <a href="{% url "projects-project-list" %}">Tableau</a>
                 </label>
             </div>
             {% comment %} <div class="fr-segmented__element">


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Correction de l'url permettant de mettre en exergue l'onglet sélectionné entre kanban et map.

Avant : 
<img width="195" height="56" alt="Capture d’écran 2025-09-16 à 16 17 25" src="https://github.com/user-attachments/assets/0c4aeb08-2939-41e9-8f66-9ba0936bd8e2" />


Après :
<img width="195" height="56" alt="Capture d’écran 2025-09-16 à 16 15 34" src="https://github.com/user-attachments/assets/78987ecf-7e10-4d81-9707-8ea9cee3b341" />


## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
