### PR TITLE
Réparation des marqueurs sur la carte de la page statistiques.

### DIFF
--- a/recoco/apps/home/templates/home/statistics.html
+++ b/recoco/apps/home/templates/home/statistics.html
@@ -123,19 +123,19 @@
                     <h4 class="fw-bold fr-mb-2v">Exemples de blocages levés</h4>
                     <div class="row">
                         <div class="col-6">
-                            <img src="{% static "/img/statistics/handshake.jpg" %}" alt="handshake" />
+                            <img src="{% static "home/img/statistics/handshake.jpg" %}" alt="handshake" />
                             <p>Qui peut m'aider pour rédiger ou relire un dossier d'appel à projet ?</p>
                         </div>
                         <div class="col-6">
-                            <img src="{% static "/img/statistics/question.jpg" %}" alt="questions" />
+                            <img src="{% static "/home/img/statistics/question.jpg" %}" alt="questions" />
                             <p>Le site de la friche a été construit illégalement. Que faire ?</p>
                         </div>
                         <div class="col-6">
-                            <img src="{% static "/img/statistics/support.jpg" %}" alt="support" />
+                            <img src="{% static "home/img/statistics/support.jpg" %}" alt="support" />
                             <p>Je ne savais pas que ce conseiller pouvait m'aider. Qui contacter ?</p>
                         </div>
                         <div class="col-6">
-                            <img src="{% static "/img/statistics/puzzle.jpg" %}" alt="puzzle" />
+                            <img src="{% static "home/img/statistics/puzzle.jpg" %}" alt="puzzle" />
                             <p>Le propriétaire du site ne répond pas. Quelle stratégie adopter ?</p>
                         </div>
                     </div>


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Réparation du chemin d'accès à l'image en static du marqueur pour la carte sur la page statistiques.

Cette PR est liée avec [cette PR de multisite.](https://github.com/betagouv/recoco-portails/pull/177)

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
