### PR TITLE
Réparation sélection de rôle page projet

### DIFF
--- a/recoco/apps/projects/views/administration.py
+++ b/recoco/apps/projects/views/administration.py
@@ -173,6 +173,7 @@ def project_administration(request, project_id):
             "is_regional_actor": is_regional_actor,
             "has_any_required_perm": has_any_required_perm,
             "advising_position": advising_position,
+            "advising": advising,
         },
     )
 

--- a/recoco/apps/projects/views/documents.py
+++ b/recoco/apps/projects/views/documents.py
@@ -21,7 +21,11 @@ from recoco.utils import has_perm_or_403
 
 from .. import models, signals
 from ..forms import DocumentUploadForm
-from ..utils import get_collaborators_for_project
+from ..utils import (
+    get_advising_context_for_project,
+    get_collaborators_for_project,
+    is_regional_actor_for_project,
+)
 
 
 @login_required
@@ -36,6 +40,14 @@ def document_list(request, project_id=None):
     )
 
     has_perm_or_403(request.user, "manage_documents", project)
+
+    is_regional_actor = is_regional_actor_for_project(
+        request.site, project, request.user, allow_national=True
+    )
+
+    advising, advising_position = get_advising_context_for_project(
+        request.user, project
+    )
 
     all_files = models.Document.objects.filter(project_id=project.pk).exclude(
         the_file__in=["", None]
@@ -58,7 +70,20 @@ def document_list(request, project_id=None):
             target_object_id=project.pk,
         ).mark_all_as_read()
 
-    return render(request, "projects/project/documents.html", locals())
+    return render(
+        request,
+        "projects/project/documents.html",
+        context={
+            "project": project,
+            "all_files": all_files,
+            "pinned_files": pinned_files,
+            "links": links,
+            "is_regional_actor": is_regional_actor,
+            "answers_with_files": answers_with_files,
+            "advising_position": advising_position,
+            "advising": advising,
+        },
+    )
 
 
 @login_required


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Dans un projet, l'onglet document ne détecte pas que l'on a un rôle et propose de rejoindre le projet, même si l'on est déjà conseiller dessus. L'onglet paramètre détecte que l'on est conseiller mais affiche quand même le cadre proposant de rejoindre le projet.

Cette PR répare les problèmes cités au dessus en ajoutant les bonnes variables aux contextes des 2 pages cités au dessus.

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
