### PR TITLE
bugifx: Un message est maintenant créé dans la conversation lors d'une reco même si le projet est en sourdine

### DIFF
--- a/recoco/apps/conversations/signals.py
+++ b/recoco/apps/conversations/signals.py
@@ -34,9 +34,6 @@ def make_message_on_action_creation(sender, task, project, user, **kwargs):
     if task.public is False:
         return
 
-    if project.project_sites.current().status == "DRAFT" or project.muted:
-        return
-
     post_public_message_with_recommendation(recommendation=task)
 
 


### PR DESCRIPTION
…s muted

Il s'agit de :
- [X] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Un message est maintenant créé dans la conversation même si le projet est en mute

=> Liens vers des éléments de Github Issue, Trello, ...

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
