### PR TITLE
✅ Ajout des listes de pages wagtail au menu connecté

### DIFF
--- a/recoco/templates/default_site/header/menu-top-secondary-right.html
+++ b/recoco/templates/default_site/header/menu-top-secondary-right.html
@@ -2,12 +2,10 @@
 {% wagtail_site as current_site %}
 {% url 'home' as home_url %}
 
-{% if not user.is_authenticated %}
-    {% for menuitem in current_site.root_page.get_children.live.in_menu %}
+{% for menuitem in current_site.root_page.get_children.live.in_menu %}
     <li x-data="{ width: window.innerWidth }"
         x-on:resize.window="width = window.innerWidth"
         class="navigation__item-resource responsive-header__element-not-mobile">
         <a href="{% pageurl menuitem %}" {% if request.path in menuitem.url and not request.path == home_url %}aria-current="page"{% endif %} class="fr-link {% if request.path in menuitem.url and not request.path == home_url %}active{% endif %}" :class="width < 992 ? 'fr-nav__link' : ''"><span class="fr-mx-1v align-middle">{{ menuitem.title }}</span></a>
     </li>
-    {% endfor %}
-{% endif %}
+{% endfor %}


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Suppression de la condition d'affichage des pages de liste de page de wagtail aux utilisateurs non connectés uniquement.
De ce fait, ces éléments apparaîtront au menu principal pour les utilisateurs connectés et déconnectés.

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
