### PR TITLE
fix(og-title): Suppression du og:title en double

### DIFF
--- a/recoco/templates/default_site/seo.html
+++ b/recoco/templates/default_site/seo.html
@@ -1,8 +1,6 @@
 <meta name="description"
       content="{% block description %}{% if request.site.configuration %}{{ request.site.configuration.description }} {% else %}{{ request.site.name }} est un outil pour aider les collectivités dans leurs dossiers{% endif %}{% endblock description %}">
 <meta name="robots" content="index, archive" />
-<meta property="og:title"
-      content="{% block og_title %}{% endblock og_title %} - {{ request.site.name }}" />
 <meta property="og:locale" content="fr" />
 <meta property="og:site_name" content="{{ request.site.name }}" />
 <meta property="og:description"


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
La base meta définissant le og:title était paramétrée (et donc dupliqué) dans un template enfant à la `base.html`.

Étant donné que le block `og_title` est défini dans chaque page héritant de base.html, impossible de paramétrer la valeur dans `seo.html`.

J'ai donc gardé seulement celle de la `base.html`

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
