### PR TITLE
Ouverture dans un nouvel onglets des liens vers des sites externes

### DIFF
--- a/recoco/apps/crm/templates/crm/project_site_handover.html
+++ b/recoco/apps/crm/templates/crm/project_site_handover.html
@@ -44,7 +44,7 @@
                                 {% endif %}
                                 <strong>{{ site.name }}</strong>
                                 <br />
-                                <span class="small"><a href="https://{{ site.domain }}" target="_blank">{{ site.domain }}</a></span>
+                                <span class="small"><a href="https://{{ site.domain }}" target="_blank">{{ site.domain }} <span class="sr-only">Nouvelle fenêtre</span></a></span>
                                 {% if ps.is_origin %}
                                     <br>
                                     <p class="fr-badge fr-badge--green-menthe">Site d'origine</p>

--- a/recoco/apps/home/templates/home/accessibility.html
+++ b/recoco/apps/home/templates/home/accessibility.html
@@ -179,14 +179,19 @@
                 <a href="https://formulaire.defenseurdesdroits.fr/"
                    class="correct-link-display"
                    target="_blank"
-                   rel="noopener">Défenseur des droits</a>
+                   rel="noopener">
+                   Défenseur des droits
+                   <span class="sr-only">Nouvelle fenêtre</span>
+                </a>
             </li>
             <li>
                 Contacter
                 <a href="https://www.defenseurdesdroits.fr/saisir/delegues"
                    class="correct-link-display"
                    target="_blank"
-                   rel="noopener">le délégué du Défenseur des droits dans votre région</a>
+                   rel="noopener">le délégué du Défenseur des droits dans votre région
+                   <span class="sr-only">Nouvelle fenêtre</span>
+                </a>
             </li>
             <li>
                 Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre) :
@@ -201,7 +206,7 @@
             Cette déclaration d’accessibilité a été créée le 23 janvier 2025 grâce au
             <a href="https://betagouv.github.io/a11y-generateur-declaration/#create"
                target="_blank"
-               rel="noopener">Générateur de Déclaration d’Accessibilité de BetaGouv</a>.
+               rel="noopener">Générateur de Déclaration d’Accessibilité de BetaGouv <span class="sr-only">Nouvelle fenêtre</span></a>.
         </p>
     </div>
 {% endblock content %}

--- a/recoco/apps/home/templates/home/followus.html
+++ b/recoco/apps/home/templates/home/followus.html
@@ -21,18 +21,18 @@
             <strong>Le 1er jeudi du mois à 15h.</strong>
         </p>
         <p>
-            Pour y participer la première fois, envoie un mail à <a href="mailto:friches@beta.gouv.fr">friches@beta.gouv.fr</a> et connecte-toi à <a href="https://us02web.zoom.us/j/82589512780" target="_new">cette url</a>.
+            Pour y participer la première fois, envoie un mail à <a href="mailto:friches@beta.gouv.fr">friches@beta.gouv.fr</a> et connecte-toi à <a href="https://us02web.zoom.us/j/82589512780" target="_blank">cette url <span class="sr-only">Nouvelle fenêtre</span></a>.
             Tu peux venir ou ne pas venir, sans prévenir. On commence à l'heure la démo dans tous les cas.
             Le contenu des démos des sprints précédents peut être retrouvé <a href="https://pad.incubateur.net/qor4zBVfQVKyxEI3a7wLTA?view"
-    target="_new">dans cette présentation</a> que l'équipe met à jour avant chaque démo.
+    target="_blank">dans cette présentation <span class="sr-only">Nouvelle fenêtre</span></a> que l'équipe met à jour avant chaque démo.
         </p>
         <p>
             Lors de la démo, on présente les travaux de l'équipe, comment le produit a évolué et les échanges avec les utilisateurs, etc. Puis on a un temps d'échange.
             Ça dure 30 à 60 min selon les échanges, et tu peux évidemment arriver en retard ou partir plus tôt.
         </p>
         <p>
-            Accédez ici aux éléments sous le format <a href="https://pad.incubateur.net/s/Cp_Sf9-8O#" target="_new">Journal de bord</a>. Accédez ici aux <a href="https://pad.incubateur.net/-fMhnZPmQKKp-o7q45E1Iw?edit#"
-    target="_new">éléments d'octobre 2020 à septembre 2021</a>.
+            Accédez ici aux éléments sous le format <a href="https://pad.incubateur.net/s/Cp_Sf9-8O#" target="_blank">Journal de bord <span class="sr-only">Nouvelle fenêtre</span></a>. Accédez ici aux <a href="https://pad.incubateur.net/-fMhnZPmQKKp-o7q45E1Iw?edit#"
+    target="_blank">éléments d'octobre 2020 à septembre 2021 <span class="sr-only">Nouvelle fenêtre</span></a>.
         </p>
     </div>
 {% endblock content %}

--- a/recoco/apps/home/templates/home/multi_annual_schema.html
+++ b/recoco/apps/home/templates/home/multi_annual_schema.html
@@ -27,19 +27,19 @@
         </p>
         <ul>
             <li>
-                UrbanVitaliz (<a href="https://www.urbanvitaliz.fr">www.urbanvitaliz.fr</a>)
+                UrbanVitaliz (<a href="https://www.urbanvitaliz.fr" target="_blank">www.urbanvitaliz.fr <span class="sr-only">Nouvelle fenêtre</span></a>)
             </li>
             <li>
-                SOSPonts (<a href="https://sosponts.recoconseil.fr">https://sosponts.recoconseil.fr</a>)
+                SOSPonts (<a href="https://sosponts.recoconseil.fr" target="_blank">https://sosponts.recoconseil.fr <span class="sr-only">Nouvelle fenêtre</span></a>)
             </li>
             <li>
-                Conseils EcoQuartier (<a href="https://ecoquartiers.recoconseil.fr/">https://ecoquartiers.recoconseil.fr/</a>)
+                Conseils EcoQuartier (<a href="https://ecoquartiers.recoconseil.fr/" target="_blank">https://ecoquartiers.recoconseil.fr/ <span class="sr-only">Nouvelle fenêtre</span></a>)
             </li>
             <li>
-                Mon Espace Collectivité (<a href="https://monespacecollectivite.incubateur.anct.gouv.fr">https://monespacecollectivite.incubateur.anct.gouv.fr</a>)
+                Mon Espace Collectivité (<a href="https://monespacecollectivite.incubateur.anct.gouv.fr" target="_blank">https://monespacecollectivite.incubateur.anct.gouv.fr <span class="sr-only">Nouvelle fenêtre</span></a>)
             </li>
             <li>
-                Recommandations-collaboratives (<a href="https://recommandations-collaboratives.beta.gouv.fr">https://recommandations-collaboratives.beta.gouv.fr</a>)
+                Recommandations-collaboratives (<a href="https://recommandations-collaboratives.beta.gouv.fr" target="_blank">https://recommandations-collaboratives.beta.gouv.fr <span class="sr-only">Nouvelle fenêtre</span></a>)
             </li>
         </ul>
         <h3>Hors périmètre</h3>

--- a/recoco/templates/default_site/account/fragments/button_pending_advisor_request.html
+++ b/recoco/templates/default_site/account/fragments/button_pending_advisor_request.html
@@ -1,8 +1,8 @@
 <div class="d-flex justify-content-between align-items-center">
     <a href="https://github.com/user-attachments/files/19451542/Tuto.conseillers.-.reco-co.pdf"
        target="_blank"
-       class="fr-btn fr-btn--tertiary-no-outline w-50 justify-content-center">Télécharger le guide conseiller en pdf</a>
+       class="fr-btn fr-btn--tertiary-no-outline w-50 justify-content-center">Télécharger le guide conseiller en pdf <span class="sr-only">Nouvelle fenêtre</span></a>
     <a href="https://www.canva.com/design/DAGaHjqFsdY/6gKxY1Xrjd7oJ2MSZdyB9Q/view"
        target="_blank"
-       class="fr-btn w-50 justify-content-center">Voir le guide du conseiller</a>
+       class="fr-btn w-50 justify-content-center">Voir le guide du conseiller <span class="sr-only">Nouvelle fenêtre</span></a>
 </div>

--- a/recoco/templates/default_site/footer/footer.html
+++ b/recoco/templates/default_site/footer/footer.html
@@ -12,11 +12,19 @@
                     <ul class="fr-footer__top-list">
                         <li>
                             <a href="https://github.com/betagouv/recommandations-collaboratives"
-                               class="fr-footer__top-link">Code Source</a>
+                               class="fr-footer__top-link"
+                               target="_blank">
+                               Code Source
+                               <span class="sr-only">Nouvelle fenêtre</span>
+                            </a>
                         </li>
                         <li>
                             <a href="https://recommandations-collaboratives.beta.gouv.fr/"
-                               class="fr-footer__top-link">Ce site est propulsé par recommandations-collaboratives</a>
+                               class="fr-footer__top-link"
+                               target="_blank">
+                               Ce site est propulsé par recommandations-collaboratives
+                               <span class="sr-only">Nouvelle fenêtre</span>
+                            </a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Les liens vers des sites externes s'ouvrent maintenant dans des nouveaux onglets.
Les liens avec des target=_new ont été rémplacé par target.
Ajout de balise pour l'accessibilité.

Resolve #1710 

Cette PR est liée avec [cette PR de recoco-portails](https://github.com/betagouv/recoco-portails/pull/190).

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
