### PR TITLE
La recherche watson inclut maintenant les organisations des dépositaires

### DIFF
--- a/recoco/apps/projects/models.py
+++ b/recoco/apps/projects/models.py
@@ -1034,6 +1034,7 @@ class ProjectSearchAdapter(watson.SearchAdapter):
         "commune__name",
         "commune__insee",
         "commune__postal",
+        "owner__profile__organization__name",
     )
 
     def tags_as_list(self, obj):


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [X] Une nouvelle fonctionnalité spontanée

Penser à lancer buildwatson sur la prod !


## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
