### PR TITLE
✅ Retour des titres en entier dans les cartes du kanban des projets

### DIFF
--- a/recoco/apps/projects/templates/projects/project/list-kanban.html
+++ b/recoco/apps/projects/templates/projects/project/list-kanban.html
@@ -103,7 +103,7 @@
                                                                 </template>
                                                                 <div class="kanban-card__project-container fr-mb-2v">
                                                                     <span class="kanban-card__project-name project-link"
-                                                                          x-text="truncate(t.name)"></span>
+                                                                          x-text="t.name"></span>
                                                                     <template x-if="t.owner?.profile?.organization">
                                                                         <span class="kanban-card__project-organization"
                                                                               x-text="t.owner.profile.organization.name"></span>

--- a/recoco/frontend/src/css/projects/kanban.scss
+++ b/recoco/frontend/src/css/projects/kanban.scss
@@ -143,8 +143,6 @@
     &__project {
       &-container {
         margin-top: -5px;
-        overflow: hidden;
-        text-overflow: ellipsis;
         display: flex;
         flex-direction: column;
       }
@@ -163,8 +161,8 @@
         color: #161616;
         font-size: var(--font-size-md);
         font-weight: 700;
-        white-space: nowrap;
-        height: 22px;
+        line-height: 1rem;
+        margin-bottom: 4px;
       }
 
       &-organization {


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

Suppression de l'élipse des titres des cartes du kanban pour voir ces titres en entier.

Resolve [#1776](https://github.com/betagouv/recommandations-collaboratives/issues/1776)

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
