### PR TITLE
Ajoute du calcul du nombre d'utilisations d'une ressource au détail par api

### DIFF
--- a/recoco/apps/resources/rest.py
+++ b/recoco/apps/resources/rest.py
@@ -1,3 +1,5 @@
+from django.db.models import Count, OuterRef, Subquery, Value
+from django.db.models.functions import Coalesce
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
@@ -7,6 +9,7 @@ from recoco.rest_api.filters import WatsonSearchFilter
 from recoco.rest_api.pagination import StandardResultsSetPagination
 from recoco.utils import has_perm
 
+from ..tasks.models import Task
 from .filters import ResourceCategoryFilter, ResourceStatusFilter
 from .importers import ResourceImporter
 from .models import Resource, ResourceAddon
@@ -55,11 +58,24 @@ class ResourceViewSet(viewsets.ModelViewSet):
         qs = Resource.on_site
         if not has_perm(self.request.user, "sites.manage_resources", self.request.site):
             qs = qs.filter(status__gt=Resource.TO_REVIEW)
+
+        task_sb = (
+            Task.objects.filter(
+                project__exclude_stats=False,
+                site_id=self.request.site,
+                resource_id=OuterRef("pk"),
+            )
+            .order_by()
+            .values("resource")
+            .annotate(c=Count("*"))
+            .values_list("c", flat=True)
+        )
         return (
             qs.with_ds_annotations()
             .select_related("created_by", "category")
             .prefetch_related("tags")
             .order_by("-created_on", "-updated_on")
+            .annotate(nb_uses=Coalesce(Subquery(task_sb), Value(0)))
         )
 
     def get_serializer_class(self):

--- a/recoco/apps/resources/serializers.py
+++ b/recoco/apps/resources/serializers.py
@@ -49,9 +49,11 @@ class ResourceSerializer(
             "departments",
             "created_by",
             "expires_on",
+            "nb_uses",
         ]
         read_only_fields = [
             "created_by",
+            "nb_uses",
         ]
 
     web_url = serializers.URLField(source="get_absolute_url", read_only=True)
@@ -63,6 +65,7 @@ class ResourceSerializer(
     departments = serializers.PrimaryKeyRelatedField(
         queryset=Department.objects, many=True
     )
+    nb_uses = serializers.IntegerField(required=False)
 
 
 class ResourceDetailSerializer(ResourceSerializer):
@@ -73,7 +76,6 @@ class ResourceDetailSerializer(ResourceSerializer):
             "created_on",
             "updated_on",
             "contacts",
-            "expires_on",
         ]
         read_only_fields = ResourceSerializer.Meta.read_only_fields + [
             "created_on",

--- a/recoco/apps/resources/tests/test_rest.py
+++ b/recoco/apps/resources/tests/test_rest.py
@@ -11,10 +11,14 @@ import json
 
 import pytest
 from django.contrib.auth import models as auth_models
+from django.contrib.sites.models import Site
 from django.contrib.sites.shortcuts import get_current_site
 from django.urls import reverse
 from guardian.shortcuts import assign_perm
 from model_bakery.recipe import Recipe, baker
+
+from recoco.apps.projects import models as project_models
+from recoco.apps.tasks import models as task_models
 
 from .. import models
 
@@ -106,6 +110,70 @@ def test_staff_can_see_unpublished_resource_in_list_api(request, api_client):
     assert response.status_code == 200
     assert response.data["count"] == 1
     assert response.data["results"][0]["title"] == resource.title
+
+
+@pytest.mark.django_db
+def test_resource_list_includes_nb_uses(request, api_client, current_site):
+    resource = Recipe(
+        models.Resource,
+        sites=[current_site],
+        status=models.Resource.PUBLISHED,
+        title=" public resource",
+    ).make()
+    Recipe(task_models.Task, resource=resource, site=current_site).make()
+    Recipe(task_models.Task, resource=resource, site=current_site).make()
+
+    url = reverse("resources-list")
+    response = api_client.get(url)
+    assert response.status_code == 200
+
+    assert "nb_uses" in response.data["results"][0]
+    assert response.data["results"][0]["nb_uses"] == 2
+
+
+@pytest.mark.django_db
+def test_resource_list_nb_uses_no_exclude_stats_projects(
+    request, api_client, current_site
+):
+    resource = Recipe(
+        models.Resource,
+        sites=[current_site],
+        status=models.Resource.PUBLISHED,
+        title=" public resource",
+    ).make()
+    project = Recipe(project_models.Project, exclude_stats=True).make()
+    Recipe(
+        task_models.Task,
+        resource=resource,
+        site=current_site,
+        project=project,
+    ).make()
+
+    url = reverse("resources-list")
+    response = api_client.get(url)
+    assert "nb_uses" in response.data["results"][0]
+    assert response.data["results"][0]["nb_uses"] == 0
+
+
+@pytest.mark.django_db
+def test_resource_list_nb_uses_no_foreign_sites(request, api_client, current_site):
+    site = Recipe(Site).make()
+    resource = Recipe(
+        models.Resource,
+        sites=[current_site, site],
+        status=models.Resource.PUBLISHED,
+        title="public resource",
+    ).make()
+    Recipe(
+        task_models.Task,
+        resource=resource,
+        site=site,
+    ).make()
+
+    url = reverse("resources-list")
+    response = api_client.get(url)
+    assert "nb_uses" in response.data["results"][0]
+    assert response.data["results"][0]["nb_uses"] == 0
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Met dans `nb_uses` la valeur du nombre de recos qui utilisent cette ressource dans des projets du site courant.
closes #1859

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
