### PR TITLE
Réparation de l'affichage du fil d'arianne lorsqu'un titre utilise une apostrophe

### DIFF
--- a/recoco/apps/resources/templates/resources/resource/update.html
+++ b/recoco/apps/resources/templates/resources/resource/update.html
@@ -10,7 +10,7 @@
     <!-- Admin navigation -->
     {% include "crm/fragments/navigation.html" with resources=True %}
     <!-- Breadcrumb -->
-    <div x-data="{ breadcrumbs: { links: [{url: '{% url 'crm-site-dashboard' %}', title: 'Admin'}, {url: '{% url 'resources-resource-search' %}', title: 'Ressources'}, {url: '{% url 'resources-resource-detail' resource.id %}', title: '{{ resource.title|truncatechars:25 }}'}], current: 'Modification de fiche ressource' } }"
+    <div x-data="{ breadcrumbs: { links: [{url: '{% url 'crm-site-dashboard' %}', title: 'Admin'}, {url: '{% url 'resources-resource-search' %}', title: 'Ressources'}, {url: '{% url 'resources-resource-detail' resource.id %}', title: `{{ resource.title|truncatechars:25 }}`},], current: 'Modification de fiche ressource' } }"
          class="fr-p-0">{% include "tools/breadcrumb.html" %}</div>
     {% include "resources/resource/form_resource.html" with edit_resource=True %}
 {% endblock content %}


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Modification du code du fil d'arianne en utilsant des accents graves pour permettre de ne pas interpreter les apostrophes dans les titres comme du code

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
