### PR TITLE
Répare la fusion d'orgas en cas de réutilisation d'un nom

### DIFF
--- a/recoco/apps/crm/tests/test_organization.py
+++ b/recoco/apps/crm/tests/test_organization.py
@@ -259,8 +259,7 @@ def test_crm_organization_merge_page_with_empty_list(request, client):
     assert response.status_code == 302
 
 
-@pytest.mark.django_db
-def test_crm_organization_merge_processing(request, client):
+def generate_orgs(request):
     site = get_current_site(request)
 
     departments = baker.make(geomatics.Department, _quantity=4)
@@ -271,6 +270,13 @@ def test_crm_organization_merge_processing(request, client):
         o.sites.add(site)
         o.departments.add(d)
         orgs.append(o)
+
+    return orgs, departments, site
+
+
+@pytest.mark.django_db
+def test_crm_organization_merge_processing(request, client):
+    orgs, departments, site = generate_orgs(request)
 
     url = reverse("crm-organization-merge")
 
@@ -291,6 +297,21 @@ def test_crm_organization_merge_processing(request, client):
     assert org.name == data["name"]
     org_dpts = (d.code for d in org.departments.all())
     assert set(org_dpts) == set(d.code for d in departments)
+
+
+@pytest.mark.django_db
+def test_crm_organization_no_fail_if_reuse_of_name(request, client):
+    orgs, departments, site = generate_orgs(request)
+
+    url = reverse("crm-organization-merge")
+
+    data = {"name": orgs[1].name, "org_ids": [o.id for o in orgs]}
+
+    with login(client) as user:
+        assign_perm("use_crm", user, site)
+        response = client.post(url, data=data)
+
+    assert response.status_code == 302
 
 
 @pytest.mark.django_db

--- a/recoco/apps/crm/views.py
+++ b/recoco/apps/crm/views.py
@@ -391,12 +391,12 @@ def merge_organizations_with_name(orgs, name):
     # update old sites in new organization
     sites = [s for s in Site.objects.filter(organizations__in=old_orgs)]
     new_org.sites.add(*sites)
-    # update new organization name
-    new_org.name = name
-    new_org.save()
     # delete old orgs
     old_ids = [o.id for o in old_orgs]
     addressbook_models.Organization.objects.filter(id__in=old_ids).delete()
+    # update new organization name
+    new_org.name = name
+    new_org.save()
 
 
 @login_required


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Assigne le nouveau nom *après* avoir supprimé les autres orgas dont celle qui avait déjà ce nom et créait une erreur sur la contrainte d'unicité
closes #1548

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
