### PR TITLE
Ajout de traces d'activités pour les rappels (A et B)

### DIFF
--- a/recoco/apps/communication/digests.py
+++ b/recoco/apps/communication/digests.py
@@ -11,6 +11,7 @@ import logging
 from dataclasses import asdict
 from itertools import groupby
 
+from actstream import action
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
@@ -130,6 +131,14 @@ def send_new_recommendations_reminders_digest_by_project(
     # Mark as dispatched
     due_reminder.mark_as_sent(sent_to=recipient)
 
+    action.send(
+        recipient,
+        verb=verbs.Recommendation.GOT_RECO_REMINDER,
+        action_object=due_reminder,
+        target=project,
+        public=False,
+    )
+
     return True
 
 
@@ -179,6 +188,14 @@ def send_whatsup_reminders_digest_by_project(
 
     # Mark as dispatched
     due_reminder.mark_as_sent(sent_to=recipient)
+
+    action.send(
+        recipient,
+        verb=verbs.Project.GOT_WHATSUP_REMINDER,
+        action_object=due_reminder,
+        target=project,
+        public=False,
+    )
 
     return True
 

--- a/recoco/apps/communication/tests/test_digests.py
+++ b/recoco/apps/communication/tests/test_digests.py
@@ -765,6 +765,33 @@ class TestSendNewRecommendationsRemindersDigestByProject:
             2025, 4, 10, 8, 0, 0, tzinfo=timezone.utc
         )
 
+    def test_activity_trace_sent(
+        self, mock_make_digest, mock_get_due_reminder, mock_make_reminder, current_site
+    ):
+        due_reminder = baker.make(Reminder)
+        project = baker.make(projects_models.Project, sites=[current_site])
+        owner = baker.make(auth.User)
+        baker.make(
+            projects_models.ProjectMember, project=project, is_owner=True, member=owner
+        )
+
+        mock_get_due_reminder.return_value = due_reminder
+        mock_make_digest.return_value = {}
+
+        with patch("recoco.apps.communication.digests.send_email"):
+            with patch("recoco.apps.communication.digests.action") as mock_action:
+                send_new_recommendations_reminders_digest_by_project(
+                    site=current_site, project=project, dry_run=False
+                )
+
+        mock_action.send.assert_called_once_with(
+            owner,
+            verb=verbs.Recommendation.GOT_RECO_REMINDER,
+            action_object=due_reminder,
+            target=project,
+            public=False,
+        )
+
 
 @pytest.mark.django_db
 @patch("recoco.apps.communication.digests.make_or_update_whatsup_reminder")
@@ -855,6 +882,33 @@ class TestSendWhatsupRemindersDigestByProject:
         assert due_reminder.sent_to == owner
         assert due_reminder.sent_on == datetime(
             2025, 4, 10, 8, 0, 0, tzinfo=timezone.utc
+        )
+
+    def test_activity_trace_sent(
+        self, mock_make_digest, mock_get_due_reminder, mock_make_reminder, current_site
+    ):
+        due_reminder = baker.make(Reminder)
+        project = baker.make(projects_models.Project, sites=[current_site])
+        owner = baker.make(auth.User)
+        baker.make(
+            projects_models.ProjectMember, project=project, is_owner=True, member=owner
+        )
+
+        mock_get_due_reminder.return_value = due_reminder
+        mock_make_digest.return_value = {}
+
+        with patch("recoco.apps.communication.digests.send_email"):
+            with patch("recoco.apps.communication.digests.action") as mock_action:
+                send_whatsup_reminders_digest_by_project(
+                    site=current_site, project=project, dry_run=False
+                )
+
+        mock_action.send.assert_called_once_with(
+            owner,
+            verb=verbs.Project.GOT_WHATSUP_REMINDER,
+            action_object=due_reminder,
+            target=project,
+            public=False,
         )
 
 

--- a/recoco/apps/reminders/apps.py
+++ b/recoco/apps/reminders/apps.py
@@ -4,3 +4,8 @@ from django.apps import AppConfig
 class RemindersConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "recoco.apps.reminders"
+
+    def ready(self):
+        from actstream import registry
+
+        registry.register(self.get_model("Reminder"))

--- a/recoco/apps/reminders/migrations/0014_backfill_reminder_activity_traces.py
+++ b/recoco/apps/reminders/migrations/0014_backfill_reminder_activity_traces.py
@@ -1,0 +1,79 @@
+# encoding: utf-8
+
+"""
+Data migration to backfill activity traces for already-sent reminders.
+
+For each sent Reminder, creates an actstream Action with the matching verb:
+  - NEW_RECO: "a reçu un rappel de recommandations"
+  - WHATS_UP: "a reçu un rappel de suivi de dossier"
+
+"""
+
+from django.db import migrations
+
+# Duplicated from verbs to keep it self contained
+VERB_BY_KIND = {
+    0: "a reçu un rappel de recommandations",  # Reminder.NEW_RECO
+    1: "a reçu un rappel de suivi de dossier",  # Reminder.WHATS_UP
+}
+
+
+def backfill_reminder_traces(apps, schema_editor):
+    Reminder = apps.get_model("reminders", "Reminder")
+    Action = apps.get_model("actstream", "Action")
+    ContentType = apps.get_model("contenttypes", "ContentType")
+
+    reminder_ct = ContentType.objects.get(app_label="reminders", model="reminder")
+    project_ct = ContentType.objects.get(app_label="projects", model="project")
+    user_ct = ContentType.objects.get(app_label="auth", model="user")
+
+    reminders = (
+        Reminder.objects.exclude(sent_on=None)
+        .exclude(sent_to=None)
+        .select_related("project", "site")
+    )
+
+    for reminder in reminders:
+        verb = VERB_BY_KIND.get(reminder.kind)
+        if verb is None:
+            continue
+
+        # skip if the action was already created
+        already_exists = Action.objects.filter(
+            actor_content_type=user_ct,
+            actor_object_id=str(reminder.sent_to_id),
+            verb=verb,
+            action_object_content_type=reminder_ct,
+            action_object_object_id=str(reminder.pk),
+            site=reminder.site,
+        ).exists()
+
+        if already_exists:
+            continue
+
+        Action.objects.create(
+            actor_content_type=user_ct,
+            actor_object_id=str(reminder.sent_to_id),
+            verb=verb,
+            action_object_content_type=reminder_ct,
+            action_object_object_id=str(reminder.pk),
+            target_content_type=project_ct,
+            target_object_id=str(reminder.project_id),
+            timestamp=reminder.sent_on,
+            public=False,
+            site=reminder.site,
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("reminders", "0013_reminder_kind_sent_on_site_project"),
+        ("actstream", "0004_add_multisite_support"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_reminder_traces,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/recoco/apps/reminders/migrations/0014_backfill_reminder_activity_traces.py
+++ b/recoco/apps/reminders/migrations/0014_backfill_reminder_activity_traces.py
@@ -21,11 +21,13 @@ VERB_BY_KIND = {
 def backfill_reminder_traces(apps, schema_editor):
     Reminder = apps.get_model("reminders", "Reminder")
     Action = apps.get_model("actstream", "Action")
+    Project = apps.get_model("projects", "Project")
+    User = apps.get_model("auth", "User")
     ContentType = apps.get_model("contenttypes", "ContentType")
 
-    reminder_ct = ContentType.objects.get(app_label="reminders", model="reminder")
-    project_ct = ContentType.objects.get(app_label="projects", model="project")
-    user_ct = ContentType.objects.get(app_label="auth", model="user")
+    reminder_ct = ContentType.objects.get_for_model(Reminder)
+    project_ct = ContentType.objects.get_for_model(Project)
+    user_ct = ContentType.objects.get_for_model(User)
 
     reminders = (
         Reminder.objects.exclude(sent_on=None)

--- a/recoco/verbs.py
+++ b/recoco/verbs.py
@@ -28,6 +28,7 @@ class Recommendation:
     DRAFTED = "a créé un brouillon de recommandation"
     CREATED = "a recommandé l'action"
     REMINDER_ADDED = "a créé un rappel sur la recommandation"
+    GOT_RECO_REMINDER = "a reçu un rappel de recommandations"
     COMMENTED = "a commenté la recommandation"
 
     SEEN = "a consulté la recommandation"
@@ -70,6 +71,8 @@ class Project:
 
     # Only related to advisor kanban
     USER_STATUS_UPDATED = "a changé l'état de son suivi dossier"
+
+    GOT_WHATSUP_REMINDER = "a reçu un rappel de suivi de dossier"
 
     SET_INACTIVE = "a mis en pause le dossier"
     SET_ACTIVE = "a réactivé le dossier"


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [X] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

Ajout de traces d'activité CRM (privées) à l'envoi de Rappels (A et B), avec deux nouveaux verbes, les tests associés, et une migration pour rattraper l'historique.

Travail préparatoire à #2018 

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
