### PR TITLE
Enregistrer des traces CRM pour les connexions par magic link par mail

### DIFF
--- a/recoco/apps/home/signals.py
+++ b/recoco/apps/home/signals.py
@@ -7,37 +7,32 @@ created: 2023-06-27 08:06:10 CEST
 
 import sentry_sdk
 from actstream import action
-from allauth.account.signals import user_logged_in as allauth_user_logged_in
 from allauth.account.signals import user_signed_up as allauth_user_signed_up
 from django.contrib.auth.models import update_last_login
 from django.contrib.auth.signals import user_logged_in
 from django.contrib.sites.shortcuts import get_current_site
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from magicauth.signals import user_logged_in as magicauth_user_logged_in
 
 from recoco import verbs
 from recoco.apps.home.models import UserProfile
 from recoco.apps.projects.utils import refresh_user_projects_in_session
 
 
-def log_connection_on_user_login(sender, user, request, **kwargs):
-    action.send(user, verb=verbs.User.LOGIN)
-
-
 @receiver(user_logged_in)
 def update_login_fields(sender, user, request, **kwargs):
     refresh_user_projects_in_session(request, user)
 
-    # Call the original django handler
-    update_last_login(sender, user, **kwargs)
+    if getattr(request.resolver_match, "app_name", None) != "hijack":
+        if not user.is_staff:
+            action.send(user, verb=verbs.User.LOGIN)
 
-    # Add the current site so that the user can access all the features
-    user.profile.sites.add(get_current_site(request))
+        # Call the original django handler
+        update_last_login(sender, user, **kwargs)
 
+        # Add the current site so that the user can access all the features
+        user.profile.sites.add(get_current_site(request))
 
-allauth_user_logged_in.connect(log_connection_on_user_login)
-magicauth_user_logged_in.connect(log_connection_on_user_login)
 
 user_logged_in.disconnect(update_last_login, dispatch_uid="update_last_login")
 

--- a/recoco/apps/home/tests/test_signals.py
+++ b/recoco/apps/home/tests/test_signals.py
@@ -1,0 +1,70 @@
+import pytest
+from django.contrib.auth import models as auth_models
+from django.urls import reverse
+from magicauth import models as magicauth_models
+from model_bakery import baker
+from sesame.utils import get_query_string
+
+from recoco.utils import login
+
+
+@pytest.mark.django_db
+def test_admin_signin_should_not_be_logged(request, client):
+    with login(client, is_staff=True) as user:
+        assert user.actor_actions.count() == 0
+
+
+@pytest.mark.django_db
+def test_allauth_signin_should_be_logged(request, client):
+    user = baker.make(auth_models.User, email="truc@truc.fr")
+    assert user.actor_actions.count() == 0
+    password = "mon mot de passe"  # nosec B105
+    user.set_password(password)
+    user.save()
+
+    url = reverse("account_login")
+    response = client.post(
+        url, data={"login": user.email, "password": password, "remember": False}
+    )
+
+    assert response.status_code == 302
+    assert user.actor_actions.count() == 1
+
+
+@pytest.mark.django_db
+def test_magicauth_signin_should_be_logged(request, client):
+    user = baker.make(auth_models.User)
+    assert user.actor_actions.count() == 0
+    token = baker.make(magicauth_models.MagicToken, user=user)
+
+    url = reverse("magicauth-validate-token", args=[token.key])
+    response = client.get(url)
+
+    assert response.status_code == 302
+    assert user.actor_actions.count() == 1
+
+
+@pytest.mark.django_db
+def test_sesame_signin_should_be_logged(request, client):
+    user = baker.make(auth_models.User)
+    assert user.actor_actions.count() == 0
+    query = get_query_string(user)
+
+    url = reverse("home") + query
+    response = client.get(url)
+
+    assert response.status_code == 302
+    assert user.actor_actions.count() == 1
+
+
+@pytest.mark.django_db
+def test_user_signin_shouldnt_be_logged_if_hijacked(request, client):
+    hijacked = baker.make(auth_models.User, username="hijacked")
+    assert hijacked.actor_actions.count() == 0
+
+    with login(client, username="hijacker", is_staff=True):
+        url = reverse("hijack:acquire")
+        response = client.post(url, data={"user_pk": hijacked.pk})
+
+    assert response.status_code == 302
+    assert hijacked.actor_actions.count() == 0

--- a/recoco/apps/home/tests/test_views.py
+++ b/recoco/apps/home/tests/test_views.py
@@ -18,7 +18,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.utils import IntegrityError
 from django.urls import reverse
 from guardian.shortcuts import assign_perm, remove_perm
-from magicauth import models as magicauth_models
 from model_bakery import baker
 from pytest_django.asserts import assertRedirects
 
@@ -638,57 +637,6 @@ def test_make_new_site(client):
         "new_example_com_admin",
     ):
         assert auth_models.Group.objects.get(name=name)
-
-
-#######################################################################
-# Signals
-#######################################################################
-
-
-@pytest.mark.django_db
-def test_admin_signin_should_not_be_logged(request, client):
-    with login(client) as user:
-        assert user.actor_actions.count() == 0
-
-
-@pytest.mark.django_db
-def test_allauth_signin_should_be_logged(request, client):
-    user = baker.make(auth_models.User, email="truc@truc.fr")
-    password = "mon mot de passe"  # nosec B105
-    user.set_password(password)
-    user.save()
-
-    url = reverse("account_login")
-    response = client.post(
-        url, data={"login": user.email, "password": password, "remember": False}
-    )
-
-    assert response.status_code == 302
-    assert user.actor_actions.count() == 1
-
-
-@pytest.mark.django_db
-def test_magicauth_signin_should_be_logged(request, client):
-    user = baker.make(auth_models.User)
-    token = baker.make(magicauth_models.MagicToken, user=user)
-
-    url = reverse("magicauth-validate-token", args=[token.key])
-    response = client.get(url)
-
-    assert response.status_code == 302
-    assert user.actor_actions.count() == 1
-
-
-@pytest.mark.django_db
-def test_user_signin_shouldnt_be_logged_if_hijacked(request, client):
-    hijacked = baker.make(auth_models.User, username="hijacked")
-
-    with login(client, username="hijacker", is_staff=True):
-        url = reverse("hijack:acquire")
-        response = client.post(url, data={"user_pk": hijacked.pk})
-
-    assert response.status_code == 302
-    assert hijacked.actor_actions.count() == 0
 
 
 # eof

--- a/recoco/apps/projects/tests/test_project_inactive.py
+++ b/recoco/apps/projects/tests/test_project_inactive.py
@@ -92,11 +92,7 @@ def test_notify_and_trace_when_project_is_set_inactive(request, client, project)
         print(a.verb)
 
     # Action traces
-    assert Action.objects.count() == 1
-
-    action = Action.objects.first()
-
-    assert action.verb == verbs.Project.SET_INACTIVE
+    assert Action.objects.filter(verb=verbs.Project.SET_INACTIVE).count() == 1
 
 
 @pytest.mark.django_db
@@ -226,11 +222,7 @@ def test_trace_when_project_is_set_active(request, client, make_project):
         print(a.verb)
 
     # Action traces
-    assert Action.objects.count() == 1
-
-    action = Action.objects.first()
-
-    assert action.verb == verbs.Project.SET_ACTIVE
+    assert Action.objects.filter(verb=verbs.Project.SET_ACTIVE).count() == 1
 
 
 @pytest.mark.django_db

--- a/recoco/apps/tasks/tests/test_tasks.py
+++ b/recoco/apps/tasks/tests/test_tasks.py
@@ -1269,10 +1269,7 @@ def test_task_status_change_is_traced_when_a_followup_issued(
     for a in Action.objects.all():
         print(a)
 
-    assert Action.objects.count() == 1
-    action = Action.objects.first()
-
-    assert action.verb == "a classé la recommandation comme «en cours»"
+    assert Action.objects.filter(verb=verbs.Recommendation.IN_PROGRESS).count() == 1
 
 
 @pytest.mark.django_db

--- a/recoco/utils.py
+++ b/recoco/utils.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import AnyStr
 from urllib.parse import parse_qs, urlencode, urljoin, urlparse, urlunparse
 
-from django.conf import settings
 from django.contrib.auth import models as auth
 from django.contrib.auth import models as auth_models
 from django.contrib.contenttypes.fields import GenericRelation
@@ -24,7 +23,7 @@ from django.db import migrations
 from django.db import models as db_models
 from django.db.models.functions import Cast
 from django.http import HttpResponseBadRequest
-from sesame.tokens import create_token
+from sesame.utils import get_parameters
 
 
 def make_site_slug(site: Site):
@@ -140,12 +139,7 @@ def build_absolute_url(path, auto_login_user=None, site=None):
             url = urlunparse(
                 parsed_url._replace(
                     query=urlencode(
-                        params
-                        | {
-                            getattr(settings, "SESAME_TOKEN_NAME", "sesame"): [
-                                create_token(user=auto_login_user)
-                            ]
-                        },
+                        params | get_parameters(auto_login_user),
                         doseq=True,
                     )
                 )


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
closes #2037
remet l'enregistrement crm dans le signal générique de connexion en créant une exception à part pour le hijacking et pour les staff

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
