### PR TITLE
✅ fix: Ordre d'affichage des reco dans le panneau de la conversation

### DIFF
--- a/recoco/apps/conversations/templates/conversations/messages/fragments/shared_contents_panel.html
+++ b/recoco/apps/conversations/templates/conversations/messages/fragments/shared_contents_panel.html
@@ -92,7 +92,7 @@ Managed by Alpine store: $store.sharedContentsPanel
                                           :key="reco.id">
                                     <div class="fr-mb-3v">
                                         <!-- Date header with grouping -->
-                                        <template x-if="index === 0 || formatDate(reco.messageCreated, { year: 'numeric', month: 'long', day: 'numeric' }) !== formatDate(reco.messageCreated, { year: 'numeric', month: 'long', day: 'numeric' })">
+                                        <template x-if="index === 0 || formatDate(reco.messageCreated, { year: 'numeric', month: 'long', day: 'numeric' }) !== formatDate($store.sharedContentsPanel.recommendations[index - 1]?.messageCreated, { year: 'numeric', month: 'long', day: 'numeric' })">
                                             <p class="shared-contents-panel__date-header"
                                                x-text="formatDate(reco.messageCreated, { year: 'numeric', month: 'long', day: 'numeric' })">
                                             </p>

--- a/recoco/frontend/src/css/miscellaneous.css
+++ b/recoco/frontend/src/css/miscellaneous.css
@@ -118,7 +118,8 @@
 }
 
 .common-dropdown__top-menu {
-  top: -230%;
+  top: auto;
+  bottom: 100%;
 }
 
 .common-dropdown.show {
@@ -189,8 +190,8 @@
 }
 
 .border-grey-light {
-  border: 1px solid #E5E5E5;
-  border-color: #E5E5E5 !important;
+  border: 1px solid #e5e5e5;
+  border-color: #e5e5e5 !important;
 }
 
 .border-blue {

--- a/recoco/frontend/src/js/store/sharedContentsPanel.js
+++ b/recoco/frontend/src/js/store/sharedContentsPanel.js
@@ -55,7 +55,26 @@ Alpine.store('sharedContentsPanel', {
   },
 
   setRecommendations(recommendations) {
-    this.recommendations = recommendations;
+    this.recommendations = [...recommendations].sort((a, b) => {
+      const dateA = new Date(a.messageCreated);
+      const dateB = new Date(b.messageCreated);
+      const dayA = new Date(
+        dateA.getFullYear(),
+        dateA.getMonth(),
+        dateA.getDate()
+      ).getTime();
+      const dayB = new Date(
+        dateB.getFullYear(),
+        dateB.getMonth(),
+        dateB.getDate()
+      ).getTime();
+      // Different day : descendant order
+      if (dayA !== dayB) {
+        return dayB - dayA;
+      }
+      // Same day : ascendant order
+      return dateA.getTime() - dateB.getTime();
+    });
   },
 
   setFiles(files) {

--- a/recoco/templates/default_site/tools/editor.html
+++ b/recoco/templates/default_site/tools/editor.html
@@ -162,7 +162,9 @@ Parameters:
                 {% endif %}
                 <!-- Recommendation module -->
                 {% if can_add_reco %}
-                    <div x-data="{ open: false }" x-on:click.outside="open = false" class="position-relative">
+                    <div x-data="{ open: false }"
+                         x-on:click.outside="open = false"
+                         class="position-relative">
                         <button data-test-id="create-task-button"
                                 x-on:click.prevent.stop="open = !open"
                                 class="fr-btn fr-btn--tertiary fr-btn--tertiary-dark-background fr-btn--sm justify-content-center fr-text--sm button-add-reco">
@@ -173,14 +175,14 @@ Parameters:
                             class="common-dropdown common-dropdown__top-menu list-unstyled flex-column item-no-space">
                             <li>
                                 <button class="fr-btn fr-btn--sm fr-btn--secondary w-100 justify-content-center"
-                                    @click.prevent="goToCreateRecommendation(`{% url 'projects-create-task' %}?project_id={{ project.pk }}{% if next_url_add_reco %}&next={% url next_url_add_reco project.pk %}{% endif %}&content=${encodeURIComponent(markdownContent || '')}`)">
-                                    Recommandation vierge
+                                        @click.prevent="goToCreateRecommendation(`{% url 'projects-create-task' %}?project_id={{ project.pk }}{% if next_url_add_reco %}&next={% url next_url_add_reco project.pk %}{% endif %}&content=${encodeURIComponent(markdownContent || '')}`)">
+                                    Nouvelle recommandation
                                 </button>
                             </li>
                             <li>
                                 <a href="{% url 'projects-project-tasks-suggest' project.pk %}"
-                                class="fr-btn fr-btn--sm fr-btn--secondary w-100 justify-content-center"
-                                data-test-id="see-suggest-task-button">Ressources suggérées</a>
+                                   class="fr-btn fr-btn--sm fr-btn--secondary w-100 justify-content-center"
+                                   data-test-id="see-suggest-task-button">Ressources suggérées</a>
                             </li>
                         </ul>
                     </div>

--- a/recoco/templates/default_site/tools/editor.html
+++ b/recoco/templates/default_site/tools/editor.html
@@ -22,6 +22,7 @@ Parameters:
 {% endcomment %}
 {% load static %}
 {% load django_vite %}
+{% load waffle_tags %}
 {% block js %}
     {% vite_asset 'js/styles/tools-editor.css.js' %}
     {% vite_asset 'js/styles/contact-card.css.js' %}
@@ -179,46 +180,48 @@ Parameters:
                                     Nouvelle recommandation
                                 </button>
                             </li>
+                            {% flag "suggest_reco_btn" %}
                             <li>
                                 <a href="{% url 'projects-project-tasks-suggest' project.pk %}"
                                    class="fr-btn fr-btn--sm fr-btn--secondary w-100 justify-content-center"
                                    data-test-id="see-suggest-task-button">Ressources suggérées</a>
                             </li>
-                        </ul>
-                    </div>
-                {% endif %}
-                <!-- Contact module -->
-                {% if can_attach_contact %}
-                    <div x-cloak>
-                        <button @click.prevent="openModalSearchContact; isEditorFocused = true;"
-                                :disabled="!canAddContact"
-                                data-test-id="button-add-contact-in-editor"
-                                class="fr-btn fr-btn--tertiary fr-btn--tertiary-dark-background fr-btn--sm fr-icon-contact-book-line fr-btn--icon-left justify-content-center fr-text--sm button-add-contact">
-                            Ajouter un contact
-                        </button>
-                        {% include "tools/contacts/search_contact_modal.html" %}
-                        <input type="hidden"
-                               {% if model %} x-model="{{ model }}.contact" x-modelable="selectedContact" {% else %} x-model="selectedContact" {% endif %}>
-                    </div>
-                {% endif %}
+                        {% endflag %}
+                    </ul>
+                </div>
+            {% endif %}
+            <!-- Contact module -->
+            {% if can_attach_contact %}
+                <div x-cloak>
+                    <button @click.prevent="openModalSearchContact; isEditorFocused = true;"
+                            :disabled="!canAddContact"
+                            data-test-id="button-add-contact-in-editor"
+                            class="fr-btn fr-btn--tertiary fr-btn--tertiary-dark-background fr-btn--sm fr-icon-contact-book-line fr-btn--icon-left justify-content-center fr-text--sm button-add-contact">
+                        Ajouter un contact
+                    </button>
+                    {% include "tools/contacts/search_contact_modal.html" %}
+                    <input type="hidden"
+                           {% if model %} x-model="{{ model }}.contact" x-modelable="selectedContact" {% else %} x-model="selectedContact" {% endif %}>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+    {% if errors %}
+        {% for error in errors %}<div class="text-danger text-start fr-mb-2v">{{ error }}</div>{% endfor %}
+    {% endif %}
+    <!-- Slot pour le bouton d'envoi -->
+    {% if show_send_button %}
+        <div class="d-flex justify-content-end">
+            <div class="d-flex gap-2 send-message">
+                <button data-test-id="send-message-conversation"
+                        :disabled="!isFormValid || sendingMessage"
+                        form="{{ form_id|default:'conversation-form' }}"
+                        class="fr-btn fr-btn--sm"
+                        :class="{'fr-icon-send-message fr-icon--sm fr-btn--icon-left': !isEditorInEditMode}"
+                        type="submit"
+                        x-text="isEditorInEditMode ? 'Modifier' : 'Envoyer'"></button>
             </div>
         </div>
-        {% if errors %}
-            {% for error in errors %}<div class="text-danger text-start fr-mb-2v">{{ error }}</div>{% endfor %}
-        {% endif %}
-        <!-- Slot pour le bouton d'envoi -->
-        {% if show_send_button %}
-            <div class="d-flex justify-content-end">
-                <div class="d-flex gap-2 send-message">
-                    <button data-test-id="send-message-conversation"
-                            :disabled="!isFormValid || sendingMessage"
-                            form="{{ form_id|default:'conversation-form' }}"
-                            class="fr-btn fr-btn--sm"
-                            :class="{'fr-icon-send-message fr-icon--sm fr-btn--icon-left': !isEditorInEditMode}"
-                            type="submit"
-                            x-text="isEditorInEditMode ? 'Modifier' : 'Envoyer'"></button>
-                </div>
-            </div>
-        {% endif %}
-    </div>
+    {% endif %}
+</div>
 </div>


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
- Changement du wording des boutton pour accéder au pousse-reco
- Ajout d'un feature flag `suggest_reco_btn` pour cacher la fonction de ressource suggérée  ⚠️ a créér en prod pour permettre l'accès seulement au portail SOS-Pont.
- Les date s'affichent correctement dans la liste des reco
- L'ordre des reco suit l'ancienne logique : les reco du jour même s'affichent dans l'ordre ascendant et les reco des autres jours s'affichent dans l'ordre descendant. 

Resolve #1983 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
