### PR TITLE
fix(conv): Correction de la condition d'affichage du bouton d'ajout d'une reco

### DIFF
--- a/recoco/apps/projects/templates/projects/project/conversations_new.html
+++ b/recoco/apps/projects/templates/projects/project/conversations_new.html
@@ -122,7 +122,7 @@
                                     </p>
                                 </div>
                             </template>
-                            {% if not is_project_owner %}
+                            {% if advising_position.is_advisor or isSwitchtender or request.user.is_staff %}
                                 {% include "tools/editor.html" with model="message" input_name=posting_form.content.name initial_content=posting_form.content.value|default:'' errors=posting_form.content.errors input_required=True can_add_reco=True next_url_add_reco="projects-project-detail-conversations" can_attach_files=True can_attach_contact=True show_send_button=True form_id="conversation-form" placeholder="Écrivez votre message ici. Ajoutez des fichiers, contacts ou une recommandation…" can_compress_editor=True on_leave_alert=True is_notification_alert=True %}
                             {% else %}
                                 {% include "tools/editor.html" with model="message" input_name=posting_form.content.name initial_content=posting_form.content.value|default:'' errors=posting_form.content.errors input_required=True can_add_reco=False next_url_add_reco="projects-project-detail-conversations" can_attach_files=True can_attach_contact=False show_send_button=True form_id="conversation-form" placeholder="Écrivez votre message ici. Vous pouvez ajouter des fichiers." can_compress_editor=True on_leave_alert=True is_notification_alert=True %}


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Le test n'était pas correct pour pouvoir afficher ce bouton. Les pages étaient bien bloquées mais le bouton s'affichait tout de même pour les demandeurs autre que le déposant du dossier.

Resolve #1689 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
