### PR TITLE
fix(list-projects) : Modification du filtre "Uniquement mes dossiers" sur le Kanban et la Map vers du back

### DIFF
--- a/recoco/apps/projects/filters.py
+++ b/recoco/apps/projects/filters.py
@@ -82,3 +82,20 @@ class DefaultNoDeletedFilter(BaseFilterBackend):
         if request_hide_deleted_projects(request):
             queryset = queryset.filter(deleted=None)
         return queryset
+
+
+class ProjectAssignedToUserFilter(BaseFilterBackend):
+    """Restrict to projects the current user is positioned on (switchtender).
+
+    The filter is enabled by the mere presence of the `my_projects` query
+    parameter (e.g. `?my_projects=true`). To disable it, omit the parameter.
+    """
+
+    def filter_queryset(self, request, queryset, view):
+        my_projects = request.GET.get("my_projects", None)
+        if my_projects:
+            queryset = queryset.filter(
+                switchtender_sites__switchtender=request.user,
+                switchtender_sites__site=request.site,
+            ).distinct()
+        return queryset

--- a/recoco/apps/projects/templates/projects/project/fragments/personal_dashboard/personal_dashboard_map.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/personal_dashboard/personal_dashboard_map.html
@@ -2,6 +2,14 @@
 <div x-cloak
      class="fr-p-0 personal-dashboard-map-container"
      :class="{'is-small':mapIsSmall}">
+    <template x-if="isBusy">
+        <div class="personal-dashboard-map-loader d-flex align-items-center justify-content-center"
+             data-cy="loader">
+            <div class="spinner-border" role="status">
+                <span class="visually-hidden">Chargement…</span>
+            </div>
+        </div>
+    </template>
     <div class="h-100 w-100 personal-dashboard-map" x-ref="map" id="map"></div>
     <div class="map-increase-height-button" x-on:click="handleMapOpen">
         <svg :class="!mapIsSmall ? 'd-none' : 'd-block'"

--- a/recoco/apps/projects/tests/test_rest.py
+++ b/recoco/apps/projects/tests/test_rest.py
@@ -246,8 +246,8 @@ def test_project_list_last_activity_filter(request, api_client):
         assert len(response.data["results"]) == 2
 
 
-@pytest.mark.django_db
-def test_project_list_my_projects_filter(request, api_client, make_project):
+@pytest.fixture
+def my_projects_filter_setup(request, api_client, make_project):
     site = get_current_site(request)
     user = baker.make(auth_models.User, is_superuser=True)
 
@@ -258,12 +258,22 @@ def test_project_list_my_projects_filter(request, api_client, make_project):
 
     api_client.force_authenticate(user=user)
 
-    url = reverse("projects-list")
+    return api_client, reverse("projects-list"), assigned_project
+
+
+@pytest.mark.django_db
+def test_project_list_without_my_projects_filter_(my_projects_filter_setup):
+    api_client, url, _ = my_projects_filter_setup
 
     # without the parameter, both projects are returned
     response = api_client.get(url)
     assert response.status_code == 200
     assert len(response.data["results"]) == 2
+
+
+@pytest.mark.django_db
+def test_project_list_with_my_projects_filter(my_projects_filter_setup):
+    api_client, url, assigned_project = my_projects_filter_setup
 
     # with the parameter, only the project the user is positioned on
     response = api_client.get(f"{url}?my_projects=true")

--- a/recoco/apps/projects/tests/test_rest.py
+++ b/recoco/apps/projects/tests/test_rest.py
@@ -247,6 +247,32 @@ def test_project_list_last_activity_filter(request, api_client):
 
 
 @pytest.mark.django_db
+def test_project_list_my_projects_filter(request, api_client, make_project):
+    site = get_current_site(request)
+    user = baker.make(auth_models.User, is_superuser=True)
+
+    assigned_project = make_project(site=site, status="READY", name="Mon projet")
+    make_project(site=site, status="READY", name="Autre projet")
+
+    utils.assign_advisor(user, assigned_project, site)
+
+    api_client.force_authenticate(user=user)
+
+    url = reverse("projects-list")
+
+    # without the parameter, both projects are returned
+    response = api_client.get(url)
+    assert response.status_code == 200
+    assert len(response.data["results"]) == 2
+
+    # with the parameter, only the project the user is positioned on
+    response = api_client.get(f"{url}?my_projects=true")
+    assert response.status_code == 200
+    assert len(response.data["results"]) == 1
+    assert response.data["results"][0]["name"] == assigned_project.name
+
+
+@pytest.mark.django_db
 def test_project_list_search_filter_fulltext(request, api_client):
     site = get_current_site(request)
     user = baker.make(auth_models.User, is_superuser=True)

--- a/recoco/apps/projects/views/rest.py
+++ b/recoco/apps/projects/views/rest.py
@@ -47,6 +47,7 @@ from ..filters import (
     DefaultNoDeletedFilter,
     DepartmentsFilter,
     ProjectActivityFilter,
+    ProjectAssignedToUserFilter,
     ProjectSiteStatusFilter,
 )
 from ..serializers import (
@@ -154,6 +155,7 @@ class ProjectList(ListAPIView):
         DepartmentsFilter,
         ProjectActivityFilter,
         ProjectSiteStatusFilter,
+        ProjectAssignedToUserFilter,
         # todo filter should not be necessary after cleaning recoco_sync 2122
         DefaultNoDeletedFilter,
     ]

--- a/recoco/frontend/src/css/personalAdvisorDashboard.css
+++ b/recoco/frontend/src/css/personalAdvisorDashboard.css
@@ -81,6 +81,13 @@ main {
   transition: height 0.25s ease;
 }
 
+.personal-dashboard-map-loader {
+  position: absolute;
+  inset: 0;
+  z-index: 1000;
+  background-color: rgba(255, 255, 255, 0.6);
+}
+
 .personal-dashboard-container-inner .project-link {
   position: relative;
   text-decoration: none;

--- a/recoco/frontend/src/js/components/KanbanProjects.js
+++ b/recoco/frontend/src/js/components/KanbanProjects.js
@@ -27,7 +27,6 @@ Alpine.data('KanbanProjects', function (currentSiteId, departments, regions) {
         title: 'À traiter',
         color_class: 'border-secondary',
         projects: [],
-        allProjects: [],
         offset: 0,
         totalCount: 0,
         hasMore: true,
@@ -38,7 +37,6 @@ Alpine.data('KanbanProjects', function (currentSiteId, departments, regions) {
         title: 'En attente',
         color_class: 'border-info',
         projects: [],
-        allProjects: [],
         offset: 0,
         totalCount: 0,
         hasMore: true,
@@ -49,7 +47,6 @@ Alpine.data('KanbanProjects', function (currentSiteId, departments, regions) {
         title: 'En cours',
         color_class: 'border-primary',
         projects: [],
-        allProjects: [],
         offset: 0,
         totalCount: 0,
         hasMore: true,
@@ -60,7 +57,6 @@ Alpine.data('KanbanProjects', function (currentSiteId, departments, regions) {
         title: 'Traité',
         color_class: 'border-success',
         projects: [],
-        allProjects: [],
         offset: 0,
         totalCount: 0,
         hasMore: true,
@@ -71,7 +67,6 @@ Alpine.data('KanbanProjects', function (currentSiteId, departments, regions) {
         title: 'Conseil interrompu',
         color_class: 'border-dark',
         projects: [],
-        allProjects: [],
         offset: 0,
         totalCount: 0,
         hasMore: true,
@@ -96,6 +91,7 @@ Alpine.data('KanbanProjects', function (currentSiteId, departments, regions) {
               departments: this.backendSearch.searchDepartment,
               limit: this.pageSize,
               status: [board.code],
+              myProjects: this.isDisplayingOnlyUserProjects,
             })
           );
 
@@ -106,7 +102,6 @@ Alpine.data('KanbanProjects', function (currentSiteId, departments, regions) {
             );
 
           board.projects = mappedProjects;
-          board.allProjects = [...board.projects];
 
           // Update pagination state
           board.totalCount = response.data.count;
@@ -115,7 +110,6 @@ Alpine.data('KanbanProjects', function (currentSiteId, departments, regions) {
           board.isLoading = false;
         })
       );
-      this.filterMyProjects();
     },
     async loadMoreProjects(board) {
       if (board.isLoading || !board.hasMore) {
@@ -131,6 +125,7 @@ Alpine.data('KanbanProjects', function (currentSiteId, departments, regions) {
           limit: this.pageSize,
           offset: board.offset,
           status: [board.code],
+          myProjects: this.isDisplayingOnlyUserProjects,
         })
       );
 
@@ -140,12 +135,10 @@ Alpine.data('KanbanProjects', function (currentSiteId, departments, regions) {
           this.currentSiteId
         );
 
-      board.allProjects = [...board.allProjects, ...mappedProjects];
-      board.offset = board.allProjects.length;
+      board.projects = [...board.projects, ...mappedProjects];
+      board.offset = board.projects.length;
       board.hasMore = board.offset < board.totalCount;
       board.isLoading = false;
-
-      this.filterMyProjects();
     },
     onColumnScroll(event, board) {
       const element = event.target;
@@ -215,7 +208,9 @@ Alpine.data('KanbanProjects', function (currentSiteId, departments, regions) {
       this.currentlyHoveredElement.classList.remove('drag-target');
       this.currentlyHoveredElement = null;
 
-      const projectId = Number(event.dataTransfer.getData('application/project-id'));
+      const projectId = Number(
+        event.dataTransfer.getData('application/project-id')
+      );
       if (!projectId) {
         return;
       }
@@ -235,24 +230,13 @@ Alpine.data('KanbanProjects', function (currentSiteId, departments, regions) {
 
       await this.getData();
     },
-    toggleMyProjectsFilter() {
+    async toggleMyProjectsFilter() {
       this.isDisplayingOnlyUserProjects = !this.isDisplayingOnlyUserProjects;
       localStorage.setItem(
         'isDisplayingOnlyUserProjects',
         this.isDisplayingOnlyUserProjects
       );
-      this.filterMyProjects();
-    },
-    filterMyProjects() {
-      this.boards.forEach((board) => {
-        if (this.isDisplayingOnlyUserProjects) {
-          board.projects = board.allProjects.filter(
-            (d) => d.is_observer || d.is_switchtender
-          );
-        } else {
-          board.projects = [...board.allProjects];
-        }
-      });
+      await this.getData();
     },
     async onSearch(event) {
       this.backendSearch.searchText = event.target.value;

--- a/recoco/frontend/src/js/components/MapDashboard.js
+++ b/recoco/frontend/src/js/components/MapDashboard.js
@@ -73,47 +73,40 @@ function MapDashboard(currentSiteId, regions) {
           searchText: searchText,
           departments: searchDepartment,
           status: ['TO_PROCESS', 'STUCK', 'READY', 'IN_PROGRESS', 'DONE'],
+          myProjects: this.isDisplayingOnlyUserProjects,
         })
       );
       this.projectList = await this.$store.projects.mapperProjetsProjectSites(
         projects.data.results,
         this.currentSiteId
       );
-      this.projectListFiltered = [...this.projectList];
-      this.filterMyProjects();
+      this.renderMap();
     },
 
-    filterMyProjects() {
-      if (this.isDisplayingOnlyUserProjects) {
-        this.projectListFiltered = this.projectList.filter(
-          (d) => d.is_observer || d.is_switchtender
-        );
-      } else {
-        this.projectListFiltered = [...this.projectList];
-      }
+    renderMap() {
       if (this.map) {
         this.map.remove();
       }
       if (this.markersLayer) {
         this.markersLayer.remove();
       }
-      const { map, markersLayer } = initMap(this.projectListFiltered);
+      const { map, markersLayer } = initMap(this.projectList);
       this.map = map;
       this.markersLayer = markersLayer;
-      if (this.projectListFiltered.length > 0) {
+      if (this.projectList.length > 0) {
         zoomToCentroid(this.map, this.markersLayer);
       } else {
         setTimeout(() => this.map.invalidateSize(), 251);
       }
     },
 
-    toggleMyProjectsFilter() {
+    async toggleMyProjectsFilter() {
       this.isDisplayingOnlyUserProjects = !this.isDisplayingOnlyUserProjects;
       localStorage.setItem(
         'isDisplayingOnlyUserProjects',
         this.isDisplayingOnlyUserProjects
       );
-      this.filterMyProjects();
+      await this.getDataFiltered();
     },
 
     async onSearch(event) {

--- a/recoco/frontend/src/js/utils/api.js
+++ b/recoco/frontend/src/js/utils/api.js
@@ -43,6 +43,7 @@ export function projectsUrl({
   limit = 2000,
   offset = 0,
   page = 1,
+  myProjects = false,
   status = [
     'PRE_DRAFT',
     'DRAFT',
@@ -75,6 +76,9 @@ export function projectsUrl({
   if (status.length) {
     status = status.map((status) => `status=${status}`).join('&');
     url = url + '&' + status;
+  }
+  if (myProjects) {
+    url = url + '&my_projects=true';
   }
   return url;
 }


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
- Création d'un filtre en backend pour n'obtenir que les dossiers sur lesquels la personne est positionné
- Positionnement de ce filtre sur le endpoint `/api/projects`
- Ajout d'un test back 
- Modification de la logique de filtre sur les pages Kanban et Map

Resolve #2140 

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
