### PR TITLE
chore(pre-commit): Ajout de gitleaks à pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,10 +15,10 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/adamchainz/django-upgrade
-    rev: "1.29.1"
+    rev: '1.29.1'
     hooks:
       - id: django-upgrade
-        args: [--target-version, "5.2"]
+        args: [--target-version, '5.2']
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.9.21
@@ -34,3 +34,8 @@ repos:
         entry: uv audit
         pass_filenames: false
         files: uv\.lock
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
- Pour l'installer sur les machine il faut lancer la commande `pre-commit install`