### PR TITLE
Correctif d'enregistrement de dernière activité

### DIFF
--- a/recoco/apps/home/middlewares.py
+++ b/recoco/apps/home/middlewares.py
@@ -47,7 +47,7 @@ class PreviousActivityMiddleware:
         ):
             try:
                 # update() rather than save() so that signals are not sent
-                UserProfile.objects.filter(pk=request.user.pk).update(
+                UserProfile.objects.filter(user_id=request.user.pk).update(
                     previous_activity_at=now,
                     previous_activity_site=request.site,
                 )


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Changements sensibles, à passer en prod dans une MEP dédiée et après avoir fait une sauvegarde

À faire pour corriger le mois erroné :
- supprimer les valeurs d'activité des utilisateurs dont last_activity_at ne fait pas partie de leurs sites associés
- `migrate home 0039 --fake`
- `migrate home 0041` pour re-calculer les valeurs sur la base de l'activité
- `migrate home --fake`

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
