### PR TITLE
fix: Suppression du champs fichier inutilisé dans la pousse reco

### DIFF
--- a/recoco/apps/projects/templates/projects/project/fragments/action_pusher/details_form.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/action_pusher/details_form.html
@@ -46,7 +46,7 @@
 <!-- Action message -->
 <div class="fr-input-group">
     <label class="push-reco__title-section" for="content">Commentaire personnalisé</label>
-    {% include "tools/editor.html" with input_file_name="the_file" model="message" input_name="content" initial_content=form.content.value|default:preserved_content|default:'' initial_content_escapejs=True errors=form.content.errors is_task=True add_file_input=True is_action_pusher=True %}
+    {% include "tools/editor.html" with model="message" input_name="content" initial_content=form.content.value|default:preserved_content|default:'' initial_content_escapejs=True errors=form.content.errors is_task=True add_file_input=False is_action_pusher=True %}
     <template x-if="message.contact">
         <input type="hidden"
                name="{{ form.contact.name }}"


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Incohérence détectée lors d'une série de tests, dans le pousse-reco : présence d'un champs d'ajout de fichier inutilisé.


## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
