### PR TITLE
Ajout de hook sur les digests (Plugins)

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -277,6 +277,26 @@ a quick index.
 
 See `Conversation Hooks & JS Integration`_ below for a worked example.
 
+``DigestSpec``
+-------------
+
+``send_digests_for_staff_users(site, user, dry_run)``
+    Called once per staff user in ``senddigests``, before the standard digest
+    loop. Implementations must query ``user.notifications(manager="on_site").unsent()``
+    filtered to the verbs they own, send their email, then call
+    ``notifications.mark_as_sent()`` to prevent double-delivery. Return the
+    count of notifications consumed (0 if nothing was sent).
+
+    The hook is called via the site-scoped plugin manager, so only plugins
+    enabled for the current site are invoked.
+
+    Example::
+
+        @hookimpl
+        def send_digests_for_staff_users(self, site, user, dry_run):
+            from .digests import send_my_digest
+            return send_my_digest(site, user, dry_run)
+
 ``CrmSpec``
 -----------
 

--- a/recoco/apps/communication/management/commands/senddigests.py
+++ b/recoco/apps/communication/management/commands/senddigests.py
@@ -15,6 +15,7 @@ from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
 
 from recoco.apps.communication import digests
+from recoco.apps.plugins.manager import get_site_plugin_manager
 from recoco.apps.projects import models as project_models
 from recoco.utils import get_group_for_site
 
@@ -50,6 +51,9 @@ class Command(BaseCommand):
 
     def send_email_digests_for_site(self, site, dry_run, user_id):
         advisor_group = get_group_for_site("advisor", site, create=True)
+        staff_group = get_group_for_site("staff", site, create=True)
+
+        pm = get_site_plugin_manager(site)
 
         # only send emails to active users and those actually linked to the current site
         user_qs = auth_models.User.objects
@@ -78,6 +82,18 @@ class Command(BaseCommand):
                         logger.info(
                             f"Sent new reco digest for {user} on {project.name}"
                         )
+
+        # Plugin digests for staff users (run first so they can consume notifications
+        # before the standard digest loop sees them)
+        logger.info("** Sending plugin digests for staff **")
+        for user in user_qs.filter(groups__in=[staff_group]):
+            for count in pm.hook.send_digests_for_staff_users(
+                site=site, user=user, dry_run=dry_run
+            ):
+                if count:
+                    logger.info(
+                        f"Plugin sent staff digest ({count} notifications) for {user}"
+                    )
 
         # Digests for non switchtenders
         logger.info("** Sending general digests **")

--- a/recoco/apps/conversations/templatetags/conversation_tags.py
+++ b/recoco/apps/conversations/templatetags/conversation_tags.py
@@ -1,7 +1,7 @@
 from django import template
 from django.utils.html import format_html
 
-from recoco.apps.plugins.manager import get_tenant_hook
+from recoco.apps.plugins.manager import get_site_plugin_manager
 
 register = template.Library()
 
@@ -9,7 +9,7 @@ register = template.Library()
 @register.simple_tag(takes_context=True)
 def conversation_plugin_node_html(context, request, project):
     """Render Alpine x-if blocks for all plugin-defined node types."""
-    hook = get_tenant_hook(request)
+    hook = get_site_plugin_manager(request)
     results = [
         r
         for r in hook.hook.conversation_message_node_html(
@@ -23,7 +23,7 @@ def conversation_plugin_node_html(context, request, project):
 @register.simple_tag(takes_context=True)
 def conversation_plugin_extra_html(context, request, project):
     """Render plugin-defined HTML injected once into the conversation page."""
-    hook = get_tenant_hook(request)
+    hook = get_site_plugin_manager(request)
     results = [
         r
         for r in hook.hook.conversation_extra_html(request=request, project=project)

--- a/recoco/apps/crm/templatetags/crm_tags.py
+++ b/recoco/apps/crm/templatetags/crm_tags.py
@@ -14,7 +14,7 @@ from django.urls import NoReverseMatch, reverse
 
 from recoco.apps.addressbook.models import Organization
 from recoco.apps.crm.models import Note
-from recoco.apps.plugins.manager import get_tenant_hook
+from recoco.apps.plugins.manager import get_site_plugin_manager
 from recoco.apps.projects.models import Project
 
 register = template.Library()
@@ -50,7 +50,9 @@ def crm_plugin_tabs(context, min_index, max_index):
     if request is None:
         return []
     tabs = []
-    for tab in get_tenant_hook(request).hook.crm_navigation_tabs(request=request):
+    for tab in get_site_plugin_manager(request).hook.crm_navigation_tabs(
+        request=request
+    ):
         if min_index < tab["index"] < max_index:
             try:
                 tab = {**tab, "url": reverse(tab["url_name"])}

--- a/recoco/apps/crm/views.py
+++ b/recoco/apps/crm/views.py
@@ -66,7 +66,7 @@ from recoco.apps.geomatics import models as geomatics
 from recoco.apps.geomatics.serializers import RegionSerializer
 from recoco.apps.home import models as home_models
 from recoco.apps.onboarding import utils as onboarding_utils
-from recoco.apps.plugins.manager import get_plugin_manager, get_tenant_hook
+from recoco.apps.plugins.manager import get_plugin_manager, get_site_plugin_manager
 from recoco.apps.projects.models import (
     Document,
     Project,
@@ -1000,7 +1000,7 @@ def project_list(request):
         .order_by("name")
     )
 
-    plugin_columns = get_tenant_hook(request).hook.crm_project_list_columns(
+    plugin_columns = get_site_plugin_manager(request).hook.crm_project_list_columns(
         request=request
     )
 

--- a/recoco/apps/plugins/apps.py
+++ b/recoco/apps/plugins/apps.py
@@ -1,11 +1,11 @@
 from django.apps import AppConfig
 
-from .manager import get_plugin_manager
-
 
 class PluginsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "recoco.apps.plugins"
 
     def ready(self):
+        from .manager import get_plugin_manager
+
         get_plugin_manager()

--- a/recoco/apps/plugins/hooks.py
+++ b/recoco/apps/plugins/hooks.py
@@ -100,6 +100,30 @@ class ConversationSpec(HookSpec):
         """
 
 
+class DigestSpec(HookSpec):
+    @hookspec
+    def send_digests_for_staff_users(self, site, user, dry_run):
+        """Called once per staff user before the standard digest loop.
+
+        Implementations should:
+
+        - Query ``user.notifications(manager="on_site").unsent()`` filtered to
+          the verbs they own.
+        - Build and send their email.
+        - Call ``notifications.mark_as_sent()`` to prevent double-delivery by
+          the standard digest loop that runs afterwards.
+
+        Return the count of notifications consumed (0 if nothing was sent).
+
+        Example::
+
+            @hookimpl
+            def send_digests_for_staff_users(self, site, user, dry_run):
+                from .digests import send_my_digest
+                return send_my_digest(site, user, dry_run)
+        """
+
+
 class CrmSpec(HookSpec):
     @hookspec
     def crm_navigation_tabs(self, request):

--- a/recoco/apps/plugins/management/base.py
+++ b/recoco/apps/plugins/management/base.py
@@ -3,6 +3,7 @@ from django.db import connection
 from psycopg.sql import SQL, Identifier
 
 from recoco.apps.home.models import SiteConfiguration
+from recoco.apps.plugins.manager import get_site_plugin_manager
 
 
 class TenantCommand(BaseCommand):
@@ -14,6 +15,10 @@ class TenantCommand(BaseCommand):
 
     By default, the schema is taken from the --schema argument. Override
     get_schema(options) to derive it from other arguments (e.g. --site-domain).
+
+    The resolved SiteConfiguration is stored as ``self.site_config`` for use
+    in handle(). Use ``self.plugin_manager`` to get a plugin manager scoped to
+    that site.
     """
 
     def add_arguments(self, parser):
@@ -28,11 +33,15 @@ class TenantCommand(BaseCommand):
             )
         return schema
 
+    @property
+    def plugin_manager(self):
+        return get_site_plugin_manager(self.site_config.site)
+
     def execute(self, *args, **options):
         schema = self.get_schema(options)
 
         try:
-            SiteConfiguration.objects.get(schema_name=schema)
+            self.site_config = SiteConfiguration.objects.get(schema_name=schema)
         except SiteConfiguration.DoesNotExist as err:
             raise CommandError(
                 f"No SiteConfiguration found for schema '{schema}'"

--- a/recoco/apps/plugins/manager.py
+++ b/recoco/apps/plugins/manager.py
@@ -5,6 +5,8 @@ import importlib.metadata
 import pluggy
 import sentry_sdk
 
+from recoco.apps.home.models import SiteConfiguration
+
 from .hooks import all_specs
 
 # Global manager holding ALL discovered plugins
@@ -41,6 +43,29 @@ def _build_plugin_manager():
                     sentry_sdk.capture_exception(e)
 
     return pm
+
+
+def get_site_plugin_manager(site):
+    """Return a plugin manager scoped to a site, for use outside HTTP requests.
+
+    Mirrors get_tenant_hook() but accepts a Site instance instead of a request.
+    Useful in management commands where no HTTP context is available.
+    """
+    pm = get_plugin_manager()
+    recoco_pm = _new_plugin_manager()
+
+    try:
+        site_config = SiteConfiguration.objects.get(site=site)
+    except SiteConfiguration.DoesNotExist:
+        return recoco_pm
+
+    if site_config.enabled_plugins:
+        enabled = set(site_config.enabled_plugins)
+        for name, plugin in pm.list_name_plugin():
+            if name in enabled:
+                recoco_pm.register(plugin, name=name)
+
+    return recoco_pm
 
 
 def get_tenant_hook(request):

--- a/recoco/apps/plugins/manager.py
+++ b/recoco/apps/plugins/manager.py
@@ -45,44 +45,30 @@ def _build_plugin_manager():
     return pm
 
 
-def get_site_plugin_manager(site):
-    """Return a plugin manager scoped to a site, for use outside HTTP requests.
-
-    Mirrors get_tenant_hook() but accepts a Site instance instead of a request.
-    Useful in management commands where no HTTP context is available.
-    """
-    pm = get_plugin_manager()
-    recoco_pm = _new_plugin_manager()
-
-    try:
-        site_config = SiteConfiguration.objects.get(site=site)
-    except SiteConfiguration.DoesNotExist:
-        return recoco_pm
-
-    if site_config.enabled_plugins:
-        enabled = set(site_config.enabled_plugins)
-        for name, plugin in pm.list_name_plugin():
-            if name in enabled:
-                recoco_pm.register(plugin, name=name)
-
-    return recoco_pm
-
-
-def get_tenant_hook(request):
+def get_site_plugin_manager(request=None, site=None):
     """
     Return a plugin manager scoped to the current tenant.
     The only enabled plugins come from the SiteConfiguration
+
+    if request is not available, try to to lookup the SiteConfiguration
+    from the Site. If neither is given, return a blank plugin manager.
     """
     pm = get_plugin_manager()
 
     recoco_pm = _new_plugin_manager()
 
+    site_config = None
+
+    if request:
+        site_config = getattr(request, "site_config", None)
+    elif site:
+        try:
+            site_config = SiteConfiguration.objects.get(site=site)
+        except SiteConfiguration.DoesNotExist:
+            return recoco_pm
+
     # Feed the scoped plugin manager with enabled plugins
-    if (
-        hasattr(request, "site_config")
-        and request.site_config
-        and request.site_config.enabled_plugins
-    ):
+    if site_config and site_config.enabled_plugins:
         enabled = set(request.site_config.enabled_plugins)
 
         for name, plugin in pm.list_name_plugin():

--- a/recoco/apps/plugins/manager.py
+++ b/recoco/apps/plugins/manager.py
@@ -69,7 +69,7 @@ def get_site_plugin_manager(request=None, site=None):
 
     # Feed the scoped plugin manager with enabled plugins
     if site_config and site_config.enabled_plugins:
-        enabled = set(request.site_config.enabled_plugins)
+        enabled = set(site_config.enabled_plugins)
 
         for name, plugin in pm.list_name_plugin():
             if name in enabled:

--- a/recoco/apps/plugins/tests.py
+++ b/recoco/apps/plugins/tests.py
@@ -12,7 +12,7 @@ from recoco.apps.home.models import SiteConfiguration
 from recoco.utils import login
 
 from .hooks import CrmSpec, ProjectSpec
-from .manager import get_tenant_hook
+from .manager import get_site_plugin_manager, get_tenant_hook
 from .middlewares import TenantPluginSchemaMiddleware
 from .routers import TenantPluginRouter
 
@@ -134,6 +134,45 @@ class TestGetTenantHook:
         results = [item for sublist in scoped.hook.get_tab_views() for item in sublist]
         assert {"name": "plugin_a"} in results
         assert {"name": "plugin_b"} not in results
+
+
+@pytest.mark.django_db
+class TestGetSitePluginManager:
+    def test_returns_only_enabled_plugins(self, current_site):
+        global_pm = make_plugin_manager(
+            ("plugin_a", PluginA()), ("plugin_b", PluginB())
+        )
+        baker.make(SiteConfiguration, site=current_site, enabled_plugins=["plugin_a"])
+
+        with patch(
+            "recoco.apps.plugins.manager.get_plugin_manager", return_value=global_pm
+        ):
+            scoped = get_site_plugin_manager(current_site)
+
+        names = [name for name, _ in scoped.list_name_plugin()]
+        assert "plugin_a" in names
+        assert "plugin_b" not in names
+
+    def test_returns_empty_manager_when_no_plugins_enabled(self, current_site):
+        global_pm = make_plugin_manager(("plugin_a", PluginA()))
+        baker.make(SiteConfiguration, site=current_site, enabled_plugins=[])
+
+        with patch(
+            "recoco.apps.plugins.manager.get_plugin_manager", return_value=global_pm
+        ):
+            scoped = get_site_plugin_manager(current_site)
+
+        assert scoped.list_name_plugin() == []
+
+    def test_returns_empty_manager_when_no_site_configuration(self, current_site):
+        global_pm = make_plugin_manager(("plugin_a", PluginA()))
+
+        with patch(
+            "recoco.apps.plugins.manager.get_plugin_manager", return_value=global_pm
+        ):
+            scoped = get_site_plugin_manager(current_site)
+
+        assert scoped.list_name_plugin() == []
 
 
 @pytest.mark.django_db

--- a/recoco/apps/plugins/tests.py
+++ b/recoco/apps/plugins/tests.py
@@ -12,11 +12,11 @@ from recoco.apps.home.models import SiteConfiguration
 from recoco.utils import login
 
 from .hooks import CrmSpec, ProjectSpec
-from .manager import get_site_plugin_manager, get_tenant_hook
+from .manager import get_site_plugin_manager
 from .middlewares import TenantPluginSchemaMiddleware
 from .routers import TenantPluginRouter
 
-# --- Fixtures & helpers for get_tenant_hook ---
+# --- Fixtures & helpers for get_site_plugin_manager ---
 
 
 @pytest.fixture
@@ -77,7 +77,7 @@ class TestGetTenantHook:
             "recoco.apps.plugins.manager.get_plugin_manager", return_value=global_pm
         ):
             request = make_request(["plugin_a"])
-            scoped = get_tenant_hook(request)
+            scoped = get_site_plugin_manager(request)
 
         names = [name for name, _ in scoped.list_name_plugin()]
         assert "plugin_a" in names
@@ -92,7 +92,7 @@ class TestGetTenantHook:
             "recoco.apps.plugins.manager.get_plugin_manager", return_value=global_pm
         ):
             request = make_request(["plugin_a", "plugin_b"])
-            scoped = get_tenant_hook(request)
+            scoped = get_site_plugin_manager(request)
 
         names = [name for name, _ in scoped.list_name_plugin()]
         assert "plugin_a" in names
@@ -105,7 +105,7 @@ class TestGetTenantHook:
             "recoco.apps.plugins.manager.get_plugin_manager", return_value=global_pm
         ):
             request = make_request([])
-            scoped = get_tenant_hook(request)
+            scoped = get_site_plugin_manager(request)
 
         assert scoped.list_name_plugin() == []
 
@@ -116,7 +116,7 @@ class TestGetTenantHook:
             "recoco.apps.plugins.manager.get_plugin_manager", return_value=global_pm
         ):
             request = make_request(["plugin_unknown"])
-            scoped = get_tenant_hook(request)
+            scoped = get_site_plugin_manager(request)
 
         assert scoped.list_name_plugin() == []
 
@@ -129,7 +129,7 @@ class TestGetTenantHook:
             "recoco.apps.plugins.manager.get_plugin_manager", return_value=global_pm
         ):
             request = make_request(["plugin_a"])
-            scoped = get_tenant_hook(request)
+            scoped = get_site_plugin_manager(request)
 
         results = [item for sublist in scoped.hook.get_tab_views() for item in sublist]
         assert {"name": "plugin_a"} in results

--- a/recoco/apps/plugins/tests.py
+++ b/recoco/apps/plugins/tests.py
@@ -147,7 +147,7 @@ class TestGetSitePluginManager:
         with patch(
             "recoco.apps.plugins.manager.get_plugin_manager", return_value=global_pm
         ):
-            scoped = get_site_plugin_manager(current_site)
+            scoped = get_site_plugin_manager(site=current_site)
 
         names = [name for name, _ in scoped.list_name_plugin()]
         assert "plugin_a" in names
@@ -160,7 +160,7 @@ class TestGetSitePluginManager:
         with patch(
             "recoco.apps.plugins.manager.get_plugin_manager", return_value=global_pm
         ):
-            scoped = get_site_plugin_manager(current_site)
+            scoped = get_site_plugin_manager(site=current_site)
 
         assert scoped.list_name_plugin() == []
 
@@ -170,7 +170,7 @@ class TestGetSitePluginManager:
         with patch(
             "recoco.apps.plugins.manager.get_plugin_manager", return_value=global_pm
         ):
-            scoped = get_site_plugin_manager(current_site)
+            scoped = get_site_plugin_manager(site=current_site)
 
         assert scoped.list_name_plugin() == []
 

--- a/recoco/apps/projects/templatetags/projects_extra.py
+++ b/recoco/apps/projects/templatetags/projects_extra.py
@@ -12,7 +12,7 @@ from django.contrib.sites.models import Site
 
 from recoco import utils as recoco_utils
 from recoco.apps.home.models import AdvisorAccessRequest
-from recoco.apps.plugins.manager import get_tenant_hook
+from recoco.apps.plugins.manager import get_site_plugin_manager
 
 from .. import models
 
@@ -105,7 +105,7 @@ def project_plugin_tabs(context):
             "active": current_view_name
             in (entry.get("active_url_names") or [entry["url_name"]]),
         }
-        for entry in get_tenant_hook(request).hook.project_tab_entries()
+        for entry in get_site_plugin_manager(request).hook.project_tab_entries()
     ]
 
 

--- a/recoco/apps/projects/views/rest.py
+++ b/recoco/apps/projects/views/rest.py
@@ -26,7 +26,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from recoco import verbs
-from recoco.apps.plugins.manager import get_tenant_hook
+from recoco.apps.plugins.manager import get_site_plugin_manager
 from recoco.rest_api.filters import (
     TagsFilterbackend,
     VectorSearchFilter,
@@ -177,7 +177,7 @@ class ProjectList(ListAPIView):
 
     def get_serializer_context(self):
         context = super().get_serializer_context()
-        pm = get_tenant_hook(self.request)
+        pm = get_site_plugin_manager(self.request)
         extra_fields = []
         for fields in pm.hook.crm_project_list_extra_serializer_fields(
             request=self.request
@@ -218,7 +218,7 @@ class ProjectList(ListAPIView):
         )
 
         # Apply plugin queryset annotations (e.g. realisations_count)
-        pm = get_tenant_hook(request)
+        pm = get_site_plugin_manager(request)
         plugin_annotations = {}
         for p_annotations in pm.hook.crm_project_list_annotations(request=request):
             plugin_annotations.update(p_annotations)

--- a/recoco/apps/resources/views.py
+++ b/recoco/apps/resources/views.py
@@ -40,7 +40,7 @@ from recoco.apps.addressbook import models as addressbook_models
 from recoco.apps.demarches_simplifiees.models import DSMapping, DSResource
 from recoco.apps.geomatics import models as geomatics_models
 from recoco.apps.hitcount.models import HitCount
-from recoco.apps.plugins.manager import get_tenant_hook
+from recoco.apps.plugins.manager import get_site_plugin_manager
 from recoco.apps.projects import models as projects
 from recoco.utils import check_if_advisor, has_perm, has_perm_or_403
 
@@ -272,7 +272,7 @@ class BaseResourceDetailView(DetailView):
         else:
             context["contacts_to_display"] = []
 
-        pm = get_tenant_hook(self.request)
+        pm = get_site_plugin_manager(self.request)
         context["resource_sidebar_panels"] = pm.hook.resource_sidebar_panels(
             resource=self.object, request=self.request
         )


### PR DESCRIPTION
Ajout d'un loop pour le staff sur le dispatch des digests, hookable par les plugins.
Documentation et réf.

Nécessaire pour l'implémentation de la plateforme artemi/depafi

Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [X] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Soit en texte, soit en images ou les deux.

=> Liens vers des éléments de Github Issue, Trello, ...

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
