### PR TITLE
Met à jour la notification de message pour garder à jour les annotations

### DIFF
--- a/recoco/apps/conversations/rest.py
+++ b/recoco/apps/conversations/rest.py
@@ -48,6 +48,10 @@ class MessageViewSet(viewsets.ModelViewSet):
         )
         signals.message_posted.send(sender=self.perform_create, message=instance)
 
+    def perform_update(self, serializer):
+        instance = serializer.save()
+        signals.message_updated.send(sender=self.perform_update, message=instance)
+
     @action(detail=True, methods=["post"], permission_classes=[IsAuthenticated])
     def mark_as_read(self, request, project_id, pk):
         """

--- a/recoco/apps/conversations/signals.py
+++ b/recoco/apps/conversations/signals.py
@@ -24,6 +24,7 @@ from .utils import (
 )
 
 message_posted = django.dispatch.Signal()
+message_updated = django.dispatch.Signal()
 
 
 @receiver(action_created)
@@ -140,6 +141,17 @@ def notify_message_created(sender, message, **kwargs):
     notify_advisors_of_project(project, notification, exclude=user)
     if not project.inactive_since:
         notify_members_of_project(project, notification, exclude=user)
+
+
+@receiver(message_updated)
+def notify_message_updated(sender, message, **kwargs):
+    new_annotations = gather_annotations_for_message_notification(message)
+    message_ct = ContentType.objects.get_for_model(message)
+    Notification.objects.filter(
+        action_object_object_id=message.id,
+        action_object_content_type=message_ct,
+        verb=verbs.Conversation.POST_MESSAGE,
+    ).update(data={"annotations": new_annotations})
 
 
 @receiver(message_posted)

--- a/recoco/apps/conversations/tests.py
+++ b/recoco/apps/conversations/tests.py
@@ -678,3 +678,56 @@ def test_message_notification_is_filled_with_metadata_upon_creation(
     assert notification
 
     assert "annotations" in notification.data.keys()
+
+
+@pytest.mark.django_db
+def test_notification_annotation_updated_on_message_edit(
+    project_ready, project_editor, request, client
+):
+    current_site = get_current_site(request)
+
+    # Add a member to receive notifications
+    member = baker.make(auth_models.User)
+    assign_collaborator(member, project_ready)
+    client.force_login(project_editor)
+
+    # Create a message with only a text node (no documents)
+    url = reverse("projects-conversations-messages-list", args=[project_ready.pk])
+    data = {"nodes": [{"position": 1, "type": "MarkdownNode", "text": "Hello"}]}
+    response = client.post(url, json.dumps(data), content_type="application/json")
+    assert response.status_code == 201
+
+    message = Message.objects.last()
+
+    # Assert notification with POST_MESSAGE verb was created, with 0 documents
+    notification = Notification.objects.filter(
+        verb=verbs.Conversation.POST_MESSAGE,
+        recipient=member,
+    ).last()
+    assert notification is not None
+    assert notification.data["annotations"]["documents"]["count"] == 0
+
+    # Create a document and edit the message to include it
+    doc = baker.make(
+        projects_models.Document,
+        site=current_site,
+        project=project_ready,
+        uploaded_by=project_editor,
+        the_link="http://un.site.fr",
+    )
+    edit_url = reverse(
+        "projects-conversations-messages-detail", args=[project_ready.pk, message.pk]
+    )
+    edit_data = {
+        "nodes": [
+            {"position": 1, "type": "DocumentNode", "document_id": doc.id},
+        ]
+    }
+    response = client.patch(
+        edit_url, json.dumps(edit_data), content_type="application/json"
+    )
+    assert response.status_code == 200
+
+    # Assert the action stream annotation was updated to reflect the new document count
+    notification.refresh_from_db()
+    assert notification.data["annotations"]["documents"]["count"] == 1


### PR DESCRIPTION


Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Lorsque les annotations ne sont pas à jour ça peut faire planter la routine d'envoi de message

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
