### PR TITLE
fix: change notification visibility

### DIFF
--- a/recoco/apps/projects/context_processors.py
+++ b/recoco/apps/projects/context_processors.py
@@ -44,7 +44,7 @@ def unread_notifications_processor(request):
 
     unread_notifications = (
         notifications_models.Notification.on_site.unread()
-        .filter(recipient=request.user, public=True)
+        .filter(recipient=request.user)
         .prefetch_related("actor__profile__organization")
         .prefetch_related("action_object")
         .prefetch_related("target")


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Modification effectuée lors d'un échange avec Guillaume. Aucune raison d'avoir le paramètre `public=True` car les notif qui remontent via la requête ne concernent que la personne connectée.
