### PR TITLE
chore: changement de la règle gitignore pour les dossier `plugins`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ recoco/frontend/plugin-entries.json
 recoco/frontend/src/js/plugins/
 
 # plugins
-plugins
+/plugins

--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,4 @@ recoco/frontend/plugin-entries.json
 recoco/frontend/src/js/plugins/
 
 # plugins
-./plugins
+plugins


### PR DESCRIPTION
A voir si on garde cette règle, ou si mon dossier n'était juste pas au bon endroit. En tout cas j'avais l'impression que la règle ne fonctionnait pas. Dispo pour échanger