### PR TITLE
Ajout d'un context manager pour factoriser les entrées/sorties de contextes de tenants [MI]

### DIFF
--- a/recoco/apps/communication/management/commands/senddigests.py
+++ b/recoco/apps/communication/management/commands/senddigests.py
@@ -15,7 +15,8 @@ from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
 
 from recoco.apps.communication import digests
-from recoco.apps.plugins.manager import get_site_plugin_manager
+from recoco.apps.plugins.manager import get_site_configuration, get_site_plugin_manager
+from recoco.apps.plugins.schema import tenant_schema_context
 from recoco.apps.projects import models as project_models
 from recoco.utils import get_group_for_site
 
@@ -53,6 +54,7 @@ class Command(BaseCommand):
         advisor_group = get_group_for_site("advisor", site, create=True)
         staff_group = get_group_for_site("staff", site, create=True)
 
+        site_config = get_site_configuration(site)
         pm = get_site_plugin_manager(site)
 
         # only send emails to active users and those actually linked to the current site
@@ -86,14 +88,15 @@ class Command(BaseCommand):
         # Plugin digests for staff users (run first so they can consume notifications
         # before the standard digest loop sees them)
         logger.info("** Sending plugin digests for staff **")
-        for user in user_qs.filter(groups__in=[staff_group]):
-            for count in pm.hook.send_digests_for_staff_users(
-                site=site, user=user, dry_run=dry_run
-            ):
-                if count:
-                    logger.info(
-                        f"Plugin sent staff digest ({count} notifications) for {user}"
-                    )
+        with tenant_schema_context(site_config):
+            for user in user_qs.filter(groups__in=[staff_group]):
+                for count in pm.hook.send_digests_for_staff_users(
+                    site=site, user=user, dry_run=dry_run
+                ):
+                    if count:
+                        logger.info(
+                            f"Plugin sent staff digest ({count} notifications) for {user}"
+                        )
 
         # Digests for non switchtenders
         logger.info("** Sending general digests **")

--- a/recoco/apps/plugins/management/base.py
+++ b/recoco/apps/plugins/management/base.py
@@ -1,10 +1,8 @@
 from django.core.management.base import BaseCommand, CommandError
-from django.db import connection
-from psycopg.sql import SQL, Identifier
 
 from recoco.apps.home.models import SiteConfiguration
 from recoco.apps.plugins.manager import get_site_plugin_manager
-from recoco.apps.plugins.resolvers import set_enabled_plugins
+from recoco.apps.plugins.schema import tenant_schema_context
 
 
 class TenantCommand(BaseCommand):
@@ -48,13 +46,9 @@ class TenantCommand(BaseCommand):
                 f"No SiteConfiguration found for schema '{schema}'"
             ) from err
 
-        with connection.cursor() as cursor:
-            cursor.execute(
-                SQL("SET search_path TO {}, public").format(Identifier(schema))
-            )
+        self.site_config = site_config
 
         # Mirror what TenantPluginSchemaMiddleware does for HTTP requests so
         # that PluginURLResolver.reverse() works inside management commands.
-        set_enabled_plugins(site_config.enabled_plugins or [])
-
-        super().execute(*args, **options)
+        with tenant_schema_context(site_config):
+            super().execute(*args, **options)

--- a/recoco/apps/plugins/manager.py
+++ b/recoco/apps/plugins/manager.py
@@ -45,6 +45,14 @@ def _build_plugin_manager():
     return pm
 
 
+def get_site_configuration(site):
+    """Return the SiteConfiguration for a given Site, or None if absent."""
+    try:
+        return SiteConfiguration.objects.get(site=site)
+    except SiteConfiguration.DoesNotExist:
+        return None
+
+
 def get_site_plugin_manager(request=None, site=None):
     """
     Return a plugin manager scoped to the current tenant.
@@ -62,9 +70,8 @@ def get_site_plugin_manager(request=None, site=None):
     if request:
         site_config = getattr(request, "site_config", None)
     elif site:
-        try:
-            site_config = SiteConfiguration.objects.get(site=site)
-        except SiteConfiguration.DoesNotExist:
+        site_config = get_site_configuration(site)
+        if site_config is None:
             return recoco_pm
 
     # Feed the scoped plugin manager with enabled plugins

--- a/recoco/apps/plugins/manager.py
+++ b/recoco/apps/plugins/manager.py
@@ -75,7 +75,7 @@ def get_site_plugin_manager(request=None, site=None):
             return recoco_pm
 
     # Feed the scoped plugin manager with enabled plugins
-    if site_config.enabled_plugins:
+    if site_config and site_config.enabled_plugins:
         enabled = set(site_config.enabled_plugins)
 
         for name, plugin in pm.list_name_plugin():

--- a/recoco/apps/plugins/manager.py
+++ b/recoco/apps/plugins/manager.py
@@ -75,7 +75,7 @@ def get_site_plugin_manager(request=None, site=None):
             return recoco_pm
 
     # Feed the scoped plugin manager with enabled plugins
-    if site_config and site_config.enabled_plugins:
+    if site_config.enabled_plugins:
         enabled = set(site_config.enabled_plugins)
 
         for name, plugin in pm.list_name_plugin():

--- a/recoco/apps/plugins/middlewares.py
+++ b/recoco/apps/plugins/middlewares.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 
-from django.db import connection
 from django.http import HttpRequest
-from psycopg.sql import SQL, Identifier
 
-from .resolvers import set_enabled_plugins
+from .schema import tenant_schema_context
 
 
 class TenantPluginSchemaMiddleware:
@@ -16,20 +14,6 @@ class TenantPluginSchemaMiddleware:
         self.get_response = get_response
 
     def __call__(self, request: HttpRequest):
-        if (
-            hasattr(request, "site_config")
-            and request.site_config
-            and request.site_config.schema_name
-        ):
-            # Publish enabled plugins to thread-local for the URL resolver
-            set_enabled_plugins(request.site_config.enabled_plugins or [])
-
-            schema = request.site_config.schema_name
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    SQL("SET search_path TO {}, public").format(Identifier(schema))
-                )
-        else:
-            set_enabled_plugins([])
-
-        return self.get_response(request)
+        site_config = getattr(request, "site_config", None)
+        with tenant_schema_context(site_config):
+            return self.get_response(request)

--- a/recoco/apps/plugins/schema.py
+++ b/recoco/apps/plugins/schema.py
@@ -1,0 +1,41 @@
+from contextlib import contextmanager
+from typing import Optional
+
+from django.db import connection
+from psycopg.sql import SQL, Identifier
+
+from recoco.apps.home.models import SiteConfiguration
+
+from .resolvers import set_enabled_plugins
+
+
+@contextmanager
+def tenant_schema_context(site_config: Optional[SiteConfiguration]):
+    """Scope the DB search_path and enabled-plugins registry to a tenant.
+
+    While the context is active, the PostgreSQL search_path is set to
+    ``<schema_name>, public`` and ``get_enabled_plugins()`` reflects the
+    tenant's ``enabled_plugins``, so plugin hooks and models resolve against
+    the right schema. Restores ``search_path`` to ``public`` and clears the
+    enabled-plugins registry on exit.
+
+    No-ops (but still clears the enabled-plugins registry) if site_config is
+    None or has no schema_name, matching TenantPluginSchemaMiddleware's
+    behaviour for tenants without a dedicated schema.
+    """
+    if not site_config or not site_config.schema_name:
+        set_enabled_plugins([])
+        yield
+        return
+
+    schema = site_config.schema_name
+    set_enabled_plugins(site_config.enabled_plugins or [])
+    with connection.cursor() as cursor:
+        cursor.execute(SQL("SET search_path TO {}, public").format(Identifier(schema)))
+
+    try:
+        yield
+    finally:
+        set_enabled_plugins([])
+        with connection.cursor() as cursor:
+            cursor.execute("SET search_path TO public")

--- a/recoco/apps/plugins/tests.py
+++ b/recoco/apps/plugins/tests.py
@@ -211,9 +211,11 @@ class TestTenantPluginSchemaMiddleware:
 
             middleware(request_mock)
 
-            cursor_instance.execute.assert_called_once_with(
+            cursor_instance.execute.assert_any_call(
                 SQL("SET search_path TO {}, public").format(Identifier("tenant_lyon"))
             )
+            # search_path is reset to public once the response has been generated
+            cursor_instance.execute.assert_called_with("SET search_path TO public")
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [X] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

les commandes comme `senddigests` ne peuvent fonctionner sans passer d'un context de tenant à un autre (besoin de surcharger les schémas et activer les plugins). Ce context manager permet de les activer/désactiver à la demande.

Il est réutilisé à la place des instructions SQL répétées comme dans `TenantCommand`.

=> Liens vers des éléments de Github Issue, Trello, ...

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
