### PR TITLE
Ajout d'un hook pour permettre l'affichage correct des notifications des plugins dans le dropdown [MI]

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -297,6 +297,24 @@ See `Conversation Hooks & JS Integration`_ below for a worked example.
             from .digests import send_my_digest
             return send_my_digest(site, user, dry_run)
 
+``NotificationSpec``
+--------------------
+
+``notification_project_verbs()``
+    Return a list of notification verb strings (see ``recoco.verbs``) to add
+    to ``show_project_verb_list`` - the notifications shown grouped under a
+    project in the notifications UI.
+
+    The hook is called via the site-scoped plugin manager from
+    ``unread_notifications_processor`` (``recoco/apps/projects/context_processors.py``),
+    so only plugins enabled for the current site contribute their verbs.
+
+    Example::
+
+        @hookimpl
+        def notification_project_verbs(self):
+            return [PluginVerbs.GIPHY_ADDED]
+
 ``CrmSpec``
 -----------
 

--- a/recoco/apps/plugins/hooks.py
+++ b/recoco/apps/plugins/hooks.py
@@ -124,6 +124,20 @@ class DigestSpec(HookSpec):
         """
 
 
+class NotificationSpec(HookSpec):
+    @hookspec
+    def notification_project_verbs(self):
+        """Return a list of notification verb strings (see ``recoco.verbs``) to add
+        to ``show_project_verb_list``, i.e. the notifications that should be shown
+        grouped under a project in the notifications UI.
+
+        Example:
+            @hookimpl
+            def notification_project_verbs(self):
+                return [PluginVerbs.GIPHY_ADDED]
+        """
+
+
 class CrmSpec(HookSpec):
     @hookspec
     def crm_navigation_tabs(self, request):

--- a/recoco/apps/plugins/tests.py
+++ b/recoco/apps/plugins/tests.py
@@ -2,16 +2,19 @@ from unittest.mock import Mock, patch
 
 import pluggy
 import pytest
+from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.db.models import Value
+from django.test import RequestFactory
 from django.urls import reverse
 from model_bakery import baker
 from psycopg.sql import SQL, Identifier
 
 from recoco.apps.home.models import SiteConfiguration
+from recoco.apps.projects.context_processors import unread_notifications_processor
 from recoco.utils import login
 
-from .hooks import CrmSpec, ProjectSpec
+from .hooks import CrmSpec, NotificationSpec, ProjectSpec
 from .manager import get_site_plugin_manager
 from .middlewares import TenantPluginSchemaMiddleware
 from .routers import TenantPluginRouter
@@ -410,3 +413,63 @@ class TestCrmProjectListColumnsHook:
 
         assert response.status_code == 200
         assert response.context["plugin_columns"] == []
+
+
+# ---------------------------------------------------------------------------
+# Notification hook extension point
+# ---------------------------------------------------------------------------
+
+FAKE_NOTIFICATION_PLUGIN_NAME = "fake_notification_plugin"
+FAKE_NOTIFICATION_VERB = "plugin_fake:custom_verb"
+
+
+class FakeNotificationPlugin:
+    """Minimal plugin contributing an extra notification verb."""
+
+    @pluggy.HookimplMarker("recoco")
+    def notification_project_verbs(self):
+        return [FAKE_NOTIFICATION_VERB]
+
+
+def make_notification_plugin_manager(plugin):
+    pm = pluggy.PluginManager("recoco")
+    pm.add_hookspecs(NotificationSpec)
+    pm.register(plugin, name=FAKE_NOTIFICATION_PLUGIN_NAME)
+    return pm
+
+
+@pytest.mark.django_db
+class TestNotificationProjectVerbsHook:
+    def test_verb_added_when_plugin_enabled(self, current_site):
+        site_config = baker.make(
+            SiteConfiguration,
+            site=current_site,
+            enabled_plugins=[FAKE_NOTIFICATION_PLUGIN_NAME],
+        )
+        user = baker.make(get_user_model())
+        request = RequestFactory().get("/")
+        request.user = user
+        request.site_config = site_config
+
+        pm = make_notification_plugin_manager(FakeNotificationPlugin())
+
+        with patch("recoco.apps.plugins.manager.get_plugin_manager", return_value=pm):
+            context = unread_notifications_processor(request)
+
+        assert FAKE_NOTIFICATION_VERB in context["show_project_verb_list"]
+
+    def test_verb_absent_when_plugin_disabled(self, current_site):
+        site_config = baker.make(
+            SiteConfiguration, site=current_site, enabled_plugins=[]
+        )
+        user = baker.make(get_user_model())
+        request = RequestFactory().get("/")
+        request.user = user
+        request.site_config = site_config
+
+        pm = make_notification_plugin_manager(FakeNotificationPlugin())
+
+        with patch("recoco.apps.plugins.manager.get_plugin_manager", return_value=pm):
+            context = unread_notifications_processor(request)
+
+        assert FAKE_NOTIFICATION_VERB not in context["show_project_verb_list"]

--- a/recoco/apps/projects/context_processors.py
+++ b/recoco/apps/projects/context_processors.py
@@ -7,6 +7,7 @@ from django.utils.timezone import localtime
 from notifications import models as notifications_models
 
 from recoco import verbs
+from recoco.apps.plugins.manager import get_site_plugin_manager
 from recoco.utils import check_if_advisor, is_admin_for_site, is_staff_for_site
 
 from .utils import can_administrate_project
@@ -83,6 +84,11 @@ def unread_notifications_processor(request):
         verbs.Project.SET_ACTIVE,
         verbs.Project.EDITED,
     ]
+
+    for plugin_verbs in get_site_plugin_manager(
+        request
+    ).hook.notification_project_verbs():
+        show_project_verb_list.extend(plugin_verbs)
 
     for notification in unread_notifications:
         date = localtime(notification.timestamp).date()


### PR DESCRIPTION
plugins(notifications): add a NotificationSpec and its hooks to allow a plugin to insert its verbs

into the show_project list.

Since the core will need a refactor, this hook is temporary and should be replaced by a more generic way to declaring the notifications format.


Il s'agit de :
- [ ] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Soit en texte, soit en images ou les deux.

=> Liens vers des éléments de Github Issue, Trello, ...

## Checklist d'acceptation de revue de code
- [ ] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [ ] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [ ] La gestion du multi-portail a été prise en compte
- [ ] L'accessibilité a été prise en compte
- [ ] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
