### PR TITLE
Correction du problème de double clique nécessaire.

### DIFF
--- a/recoco/apps/crm/templates/crm/organization_merge.html
+++ b/recoco/apps/crm/templates/crm/organization_merge.html
@@ -50,7 +50,7 @@
                                 <li>
                                     <button type="button"
                                             class="fr-tag"
-                                            @click="name = '{{ organization.name|escapejs }}'"
+                                            @click="$event.stopImmediatePropagation(); name = '{{ organization.name|escapejs }}'"
                                             :aria-pressed="name === '{{ organization.name|escapejs }}'">
                                         {{ organization.name }}
                                     </button>


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [x] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Dans la page de fusion d'organisations, lorsque je clique sur le nom d'une des organisations impliquées dans la fusion, le bouton change bien le nom de la future organisation une fois ces dernières fusionnées, mais visuellement, le bouton n'est pas "coché". Il l'est maintenant en stoppant la propagation automatique du dsfr et d'alpine pour que les 2 soient pris en compte.

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
