### PR TITLE
Cacher l'onglet paramètre du site au staff 

### DIFF
--- a/recoco/apps/crm/templates/crm/fragments/navigation.html
+++ b/recoco/apps/crm/templates/crm/fragments/navigation.html
@@ -4,6 +4,7 @@
 {% load projects_extra %}
 {% load django_vite %}
 {% load crm_tags %}
+{% get_obj_perms request.user for request.site as "user_site_perms" user_perm_checker %}
 {% block js %}
     {% vite_asset 'js/styles/marianne.css.js' %}
     {% vite_asset 'js/apps/CRM/crmNavigation.js' %}
@@ -94,18 +95,20 @@
                     <a class="stretched-link" href="{% url 'crm-resource-list' %}">Ressources</a>
                 </label>
             </div>
-            <div class="fr-segmented__element">
-                <input value="overview"
-                       type="radio"
-                       {% if site_configuration %}checked{% endif %}
-                       aria-checked="{% if site_configuration %}true{% else %}false{% endif %}"
-                       id="segmented-control-site-configuration"
-                       name="segmented-control-site-configuration"
-                       @click="window.location='{% url 'crm-site-configuration' %}'">
-                <label class="fr-label" for="segmented-control-site-configuration">
-                    <a class="stretched-link" href="{% url 'crm-site-configuration' %}">Paramètres du site</a>
-                </label>
-            </div>
+            {% if "manage_configuration" in user_site_perms %}
+                <div class="fr-segmented__element">
+                    <input value="overview"
+                        type="radio"
+                        {% if site_configuration %}checked{% endif %}
+                        aria-checked="{% if site_configuration %}true{% else %}false{% endif %}"
+                        id="segmented-control-site-configuration"
+                        name="segmented-control-site-configuration"
+                        @click="window.location='{% url 'crm-site-configuration' %}'">
+                    <label class="fr-label" for="segmented-control-site-configuration">
+                        <a class="stretched-link" href="{% url 'crm-site-configuration' %}">Paramètres du site</a>
+                    </label>
+                </div>
+            {% endif %}
         </div>
     </fieldset>
     <div class="flex-grow-1">


### PR DESCRIPTION
Il s'agit de :
- [x] Une correction de bug
- [x] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements

L'onglet "paramètres du site" est maintenant caché au staff pour être disponible uniquement aux administrateurs.

Resolve https://github.com/betagouv/recommandations-collaboratives/issues/2310

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [x] Des tests couvrant le code changé ont été ajoutés/modifiés
- [x] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
