### PR TITLE
quickfix : protection contre le mode embed sauvage

### DIFF
--- a/recoco/apps/home/middlewares.py
+++ b/recoco/apps/home/middlewares.py
@@ -9,6 +9,7 @@ from django.http import HttpRequest
 from django.utils import timezone
 from sesame.middleware import AuthenticationMiddleware as SesameAuthenticationMiddleware
 from sesame.utils import get_user
+from waffle.templatetags import waffle_tags
 
 from recoco.apps.home.adapters import confirm_email
 from recoco.apps.home.models import SiteConfiguration, UserProfile
@@ -45,7 +46,7 @@ class EmbedMiddleware:
         if (
             request.headers.get("Sec-Fetch-Dest") == "iframe"
             or request.GET.get("embed") == "1"
-        ):
+        ) and waffle_tags.flag_is_active(request, "embeddable"):
             request.session["is_embedded"] = True
         request.is_embedded = request.session.get("is_embedded", False)
 

--- a/recoco/apps/home/tests/test_middlewares.py
+++ b/recoco/apps/home/tests/test_middlewares.py
@@ -10,6 +10,7 @@ from django.http import HttpResponse
 from django.urls import reverse
 from model_bakery import baker
 from sesame.utils import get_query_string
+from waffle.testutils import override_flag
 
 from conftest import setup_sesame_cookie
 from recoco.apps.home.context_processors import embed
@@ -231,33 +232,45 @@ class TestEmbedMiddleware:
         request.site_config = None
         return request
 
+    @pytest.mark.django_db
+    @override_flag("embeddable", active=True)
     def test_sets_embedded_from_sec_fetch_dest_header(self):
         request = self._make_request(headers={"Sec-Fetch-Dest": "iframe"})
         self.middleware(request)
         assert request.session["is_embedded"] is True
         assert request.is_embedded is True
 
+    @pytest.mark.django_db
+    @override_flag("embeddable", active=True)
     def test_sets_embedded_from_query_param(self):
         request = self._make_request(get_params={"embed": "1"})
         self.middleware(request)
         assert request.session["is_embedded"] is True
         assert request.is_embedded is True
 
+    @pytest.mark.django_db
+    @override_flag("embeddable", active=True)
     def test_not_embedded_by_default(self):
         request = self._make_request()
         self.middleware(request)
         assert request.is_embedded is False
 
+    @pytest.mark.django_db
+    @override_flag("embeddable", active=True)
     def test_not_embedded_when_embed_param_is_not_one(self):
         request = self._make_request(get_params={"embed": "0"})
         self.middleware(request)
         assert request.is_embedded is False
 
+    @pytest.mark.django_db
+    @override_flag("embeddable", active=True)
     def test_persists_embedded_state_from_session(self):
         request = self._make_request(session={"is_embedded": True})
         self.middleware(request)
         assert request.is_embedded is True
 
+    @pytest.mark.django_db
+    @override_flag("embeddable", active=True)
     def test_does_not_set_session_without_trigger(self):
         session = {}
         request = self._make_request(session=session)
@@ -279,6 +292,8 @@ class TestEmbedMiddlewareCSP:
         request.site_config = site_config
         return request
 
+    @pytest.mark.django_db
+    @override_flag("embeddable", active=True)
     def test_sets_frame_ancestors_header_when_origins_configured(self):
         site_config = Mock(embed_allowed_origins=["https://partner.example.fr"])
         request = self._make_request(site_config=site_config)
@@ -290,6 +305,8 @@ class TestEmbedMiddlewareCSP:
         }
         assert response.xframe_options_exempt is True
 
+    @pytest.mark.django_db
+    @override_flag("embeddable", active=True)
     def test_joins_multiple_allowed_origins(self):
         site_config = Mock(
             embed_allowed_origins=[
@@ -308,6 +325,8 @@ class TestEmbedMiddlewareCSP:
             ]
         }
 
+    @pytest.mark.django_db
+    @override_flag("embeddable", active=True)
     def test_no_csp_header_when_no_allowed_origins(self):
         site_config = Mock(embed_allowed_origins=[])
         request = self._make_request(site_config=site_config)
@@ -317,6 +336,8 @@ class TestEmbedMiddlewareCSP:
         assert "_csp_update" not in response
         assert getattr(response, "xframe_options_exempt", False) is False
 
+    @pytest.mark.django_db
+    @override_flag("embeddable", active=True)
     def test_no_csp_header_when_no_site_config(self):
         request = self._make_request(site_config=None)
 
@@ -325,6 +346,8 @@ class TestEmbedMiddlewareCSP:
         assert "_csp_update" not in response
         assert getattr(response, "xframe_options_exempt", False) is False
 
+    @pytest.mark.django_db
+    @override_flag("embeddable", active=True)
     def test_no_csp_header_when_not_embedded(self):
         site_config = Mock(embed_allowed_origins=["https://partner.example.fr"])
         request = self._make_request(site_config=site_config, embedded=False)
@@ -335,6 +358,7 @@ class TestEmbedMiddlewareCSP:
         assert getattr(response, "xframe_options_exempt", False) is False
 
     @pytest.mark.django_db
+    @override_flag("embeddable", active=True)
     def test_csp_update_is_appended_to_content_security_policy_header(self, client):
         # Bypass the site_config/allowed_origins logic (covered by the tests
         # above) to test how _csp_update is interpreted


### PR DESCRIPTION
this is only a quickfix, the feature needs re-thinking

Il s'agit de :
- [x] Une correction de bug
- [ ] Une nouvelle fonctionnalité programmée
- [ ] Une nouvelle fonctionnalité spontanée

## Décrivez vos changements
Les gens se piégeaient dans la vue embed parce que les ressources sont un embed.
Ajout d'un feature flag our protéger les autres portails de MEC

## Checklist d'acceptation de revue de code
- [x] Aucun texte ne fait référence à du vocabulaire spécifique d'un métier
- [x] Mon code est auto-documenté ou la documentation a été mise à jour/créée
- [x] La gestion du multi-portail a été prise en compte
- [x] L'accessibilité a été prise en compte
- [x] Pre-commit est configuré et a été lancé
- [ ] Des tests couvrant le code changé ont été ajoutés/modifiés
- [ ] L'ensemble des tests front et back sont au vert

## Demandes
- [ ] Je souhaite un déploiement en préproduction
