### PR TITLE
fix(security): assainir le HTML/markdown rendu sur tous les champs *_rendered

### DIFF
--- a/recoco/apps/communication/digests.py
+++ b/recoco/apps/communication/digests.py
@@ -18,7 +18,6 @@ from django.contrib.sites.models import Site
 from django.db.models.query import QuerySet
 from django.urls import reverse
 from django_gravatar.helpers import get_gravatar_url
-from markdownx.utils import markdownify
 
 from recoco import utils, verbs
 from recoco.apps.home.models import SiteConfiguration
@@ -603,7 +602,7 @@ def make_msg_digest_by_user_and_project(notifications_qs, user, project, site):
     counts_less_recap = aggregated_counts.copy()
     if first_text_msg:
         counts_less_recap["message"] -= 1
-        first_text = markdownify(
+        first_text = utils.render_markdown(
             "\n\n".join(
                 node.text
                 for node in first_text_msg.nodes.filter(

--- a/recoco/apps/conversations/models.py
+++ b/recoco/apps/conversations/models.py
@@ -5,10 +5,11 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models, transaction
 from django.urls import reverse
 from django.utils.http import urlencode
-from markdownx.utils import markdownify
 from model_utils.models import TimeStampedModel
 from notifications.models import Notification
 from polymorphic.models import PolymorphicModel
+
+from recoco.utils import render_markdown
 
 
 class MessageNotDeletedManager(models.Manager):
@@ -97,14 +98,14 @@ class RecommendationNode(Node, MarkdownTextMixin):
 
         if self.recommendation.resource is None:
             res = res | {
-                "text": markdownify(self.text),
+                "text": render_markdown(self.text),
                 "title": self.recommendation.intent,
             }
         else:
             res = res | {
                 "title": self.recommendation.resource.title,
                 "subtitle": self.recommendation.resource.subtitle,
-                "text": markdownify(self.text),
+                "text": render_markdown(self.text),
             }
         return res
 

--- a/recoco/apps/crm/models.py
+++ b/recoco/apps/crm/models.py
@@ -8,11 +8,11 @@ from django.db.models.signals import post_migrate
 from django.dispatch import receiver
 from django.urls import reverse
 from django.utils import timezone
-from markdownx.utils import markdownify
 from taggit.managers import TaggableManager
 
 from recoco.apps.addressbook import models as addressbook_models
 from recoco.apps.projects import models as projects_models
+from recoco.utils import render_markdown
 
 from . import apps
 
@@ -150,7 +150,7 @@ class Note(models.Model):
     @property
     def content_rendered(self):
         """Return content as markdown"""
-        return markdownify(self.content)
+        return render_markdown(self.content)
 
     def __str__(self):
         if self.title:

--- a/recoco/apps/projects/models.py
+++ b/recoco/apps/projects/models.py
@@ -27,7 +27,6 @@ from django.dispatch import receiver
 from django.urls import reverse
 from django.utils import timezone
 from guardian.shortcuts import get_objects_for_user
-from markdownx.utils import markdownify
 from model_utils.models import TimeStampedModel
 from notifications import models as notifications_models
 from notifications.models import Notification
@@ -40,6 +39,7 @@ from recoco.utils import (
     CastedGenericRelation,
     check_if_advisor,
     has_perm,
+    render_markdown,
     strip_accents,
 )
 
@@ -574,7 +574,7 @@ class Project(models.Model):
     @property
     def advisors_note_rendered(self):
         """Return synopsis as markdown"""
-        return markdownify(self.advisors_note)
+        return render_markdown(self.advisors_note)
 
     advisors_note_on = models.DateTimeField(
         verbose_name="Rédigé le", null=True, blank=True
@@ -611,7 +611,7 @@ class Project(models.Model):
     @property
     def impediments_rendered(self):
         """Return impediments as markdown"""
-        return markdownify(self.impediments)
+        return render_markdown(self.impediments)
 
     switchtenders = models.ManyToManyField(
         auth_models.User,
@@ -946,7 +946,7 @@ class Note(models.Model):
     @property
     def content_rendered(self):
         """Return content as markdown"""
-        return markdownify(self.content)
+        return render_markdown(self.content)
 
     deleted = models.DateTimeField(null=True, blank=True)
 

--- a/recoco/apps/projects/templates/projects/project/fragments/action_comment.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/action_comment.html
@@ -1,7 +1,9 @@
 {% load gravatar %}
 {% load humanize %}
 <div class="d-flex flex-column fr-m-2v fr-p-3w comment {% if followup.pk in followups_with_notifications %}bg-light-yellow{% else %}bg-light{% endif %}">
-    <p class="fr-m-0 fr-p-0">{{ comment|safe }}</p>
+    {# `comment` is expected to already be sanitized HTML (rendered via
+       recoco.utils.render_markdown) -- callers must not pass raw user input. #}
+    <div class="fr-m-0 fr-p-0">{{ comment|safe }}</div>
     <div>
         <!-- Image -->
         <img src="{% gravatar_url author.email 16 %}"

--- a/recoco/apps/projects/templates/projects/project/fragments/action_list_item.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/action_list_item.html
@@ -275,12 +275,12 @@
                                 </span>
                                 {% if followup.comment %}
                                     <p class="fr-m-0 fr-p-0">
-                                        <q>&nbsp;{{ followup.comment|safe }}&nbsp;</q>
+                                        <q>&nbsp;{{ followup.comment_rendered|safe }}&nbsp;</q>
                                     </p>
                                 {% endif %}
                             </div>
                         {% else %}
-                            {% include "projects/project/fragments/action_comment.html" with followup=followup comment=followup.comment author=followup.who date=followup.timestamp %}
+                            {% include "projects/project/fragments/action_comment.html" with followup=followup comment=followup.comment_rendered author=followup.who date=followup.timestamp %}
                         {% endif %}
                     {% endfor %}
                     {% if can_manage and task.public %}

--- a/recoco/apps/projects/templates/projects/project/fragments/action_list_item.html
+++ b/recoco/apps/projects/templates/projects/project/fragments/action_list_item.html
@@ -274,9 +274,9 @@
                                     <small class="align-middle text-muted">{{ followup.timestamp|naturalday }}</small>
                                 </span>
                                 {% if followup.comment %}
-                                    <p class="fr-m-0 fr-p-0">
+                                    <div class="fr-m-0 fr-p-0">
                                         <q>&nbsp;{{ followup.comment_rendered|safe }}&nbsp;</q>
-                                    </p>
+                                    </div>
                                 {% endif %}
                             </div>
                         {% else %}

--- a/recoco/apps/resources/models.py
+++ b/recoco/apps/resources/models.py
@@ -22,7 +22,6 @@ from django.db.models.signals import post_migrate
 from django.dispatch import receiver
 from django.urls import reverse
 from django.utils import timezone
-from markdownx.utils import markdownify
 from model_clone.models import CloneMixin
 from model_utils.models import TimeStampedModel
 from taggit.managers import TaggableManager
@@ -30,6 +29,7 @@ from watson import search as watson
 
 from recoco.apps.addressbook import models as addressbook_models
 from recoco.apps.geomatics import models as geomatics_models
+from recoco.utils import render_markdown
 
 # from recoco.apps.tasks.models import Task
 from . import apps
@@ -253,7 +253,7 @@ class Resource(CloneMixin, models.Model):
 
     def content_rendered(self):
         """Return content as markdown"""
-        return markdownify(self.content)
+        return render_markdown(self.content)
 
     deleted = models.DateTimeField(null=True, blank=True)
 

--- a/recoco/apps/survey/models.py
+++ b/recoco/apps/survey/models.py
@@ -13,7 +13,6 @@ from django.db.models.signals import post_migrate
 from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.functional import cached_property
-from markdownx.utils import markdownify
 from model_clone import CloneMixin
 from tagging.fields import TagField
 from tagging.models import Tag
@@ -21,6 +20,7 @@ from tagging.registry import register as tagging_register
 from taggit.managers import TaggableManager
 
 from recoco.apps.projects import models as projects_models
+from recoco.utils import render_markdown
 
 from . import apps
 from .utils import compute_qs_completion
@@ -177,14 +177,14 @@ class Question(CloneMixin, models.Model):
     @property
     def how_rendered(self):
         """Return content as markdown"""
-        return markdownify(self.how)
+        return render_markdown(self.how)
 
     why = models.TextField(default="", blank=True, verbose_name="Pourquoi ?")
 
     @property
     def why_rendered(self):
         """Return content as markdown"""
-        return markdownify(self.why)
+        return render_markdown(self.why)
 
     # does this question expect a multiple choice or single choice answer
     is_multiple = models.BooleanField(

--- a/recoco/apps/tasks/models.py
+++ b/recoco/apps/tasks/models.py
@@ -17,7 +17,6 @@ from django.db import models
 from django.db.models import Q
 from django.urls import reverse
 from django.utils import timezone
-from markdownx.utils import markdownify
 from ordered_model.models import OrderedModel, OrderedModelManager, OrderedModelQuerySet
 from tagging.fields import TagField
 from tagging.models import TaggedItem  # remains necessary for survey-related code
@@ -28,7 +27,7 @@ from recoco.apps.addressbook import models as addressbook_models
 from recoco.apps.geomatics import models as geomatics_models
 from recoco.apps.projects import models as projects_models
 from recoco.apps.resources import models as resources
-from recoco.utils import truncate_string
+from recoco.utils import render_markdown, truncate_string
 
 FEED_LABEL_MAX_LENGTH = 50
 
@@ -192,7 +191,7 @@ class Task(OrderedModel):
     @property
     def content_rendered(self):
         """Return content as markdown"""
-        return markdownify(self.content)
+        return render_markdown(self.content)
 
     deadline = models.DateField(null=True, blank=True)
 
@@ -294,7 +293,7 @@ class TaskFollowup(models.Model):
     @property
     def comment_rendered(self):
         """Return comment as markdown"""
-        return markdownify(self.comment)
+        return render_markdown(self.comment)
 
     def __str__(self):  # pragma: nocover
         return f"TaskFollowup{self.id}"

--- a/recoco/apps/tasks/tests/test_tasks.py
+++ b/recoco/apps/tasks/tests/test_tasks.py
@@ -34,6 +34,39 @@ from recoco.utils import login
 from .. import models
 
 ########################################################################
+# Content sanitization
+########################################################################
+
+
+@pytest.mark.django_db
+def test_task_content_rendered_strips_embedded_script_tags(current_site, project):
+    task = baker.make(
+        models.Task,
+        project=project,
+        site=current_site,
+        content="<script>alert(document.cookie)</script>",
+    )
+
+    assert "<script>" not in task.content_rendered
+    assert "alert(document.cookie)" not in task.content_rendered
+
+
+@pytest.mark.django_db
+def test_task_followup_comment_rendered_strips_embedded_script_tags(
+    current_site, project
+):
+    task = baker.make(models.Task, project=project, site=current_site, public=True)
+    followup = baker.make(
+        models.TaskFollowup,
+        task=task,
+        comment="<script>alert(document.cookie)</script>",
+    )
+
+    assert "<script>" not in followup.comment_rendered
+    assert "alert(document.cookie)" not in followup.comment_rendered
+
+
+########################################################################
 # Task Recommendation
 ########################################################################
 

--- a/recoco/tests.py
+++ b/recoco/tests.py
@@ -254,6 +254,30 @@ def test_return_admin(client, request):
     assert set(utils.get_admin_for_site(site)) == set(admin_group.user_set.all())
 
 
+def test_render_markdown_strips_embedded_script_tags():
+    rendered = utils.render_markdown("<script>alert(document.cookie)</script>")
+
+    assert "<script>" not in rendered
+    assert "alert(document.cookie)" not in rendered
+
+
+def test_render_markdown_strips_embedded_event_handlers():
+    rendered = utils.render_markdown('<img src=x onerror="alert(1)">')
+
+    assert "onerror" not in rendered
+
+
+def test_render_markdown_keeps_basic_markdown_formatting():
+    rendered = utils.render_markdown("**bold** and _italic_")
+
+    assert "<strong>bold</strong>" in rendered
+    assert "<em>italic</em>" in rendered
+
+
+def test_render_markdown_handles_none():
+    assert utils.render_markdown(None) == ""
+
+
 class CustomBaker(baker.Baker):
     def get_fields(self):
         return [

--- a/recoco/utils.py
+++ b/recoco/utils.py
@@ -26,7 +26,18 @@ from django.db import migrations
 from django.db import models as db_models
 from django.db.models.functions import Cast
 from django.http import HttpResponse, HttpResponseBadRequest
+from markdownx.utils import markdownify
 from sesame.utils import get_parameters
+
+
+def render_markdown(text: AnyStr | None) -> str:
+    """Render markdown to HTML, stripping any embedded/unsafe HTML.
+
+    `markdownx.utils.markdownify` passes raw HTML embedded in the source
+    straight through, so its output is never safe to render with `|safe`
+    on its own -- always sanitize it here first.
+    """
+    return nh3.clean(markdownify(text or ""))
 
 
 def make_site_slug(site: Site):

--- a/recoco/utils.py
+++ b/recoco/utils.py
@@ -29,6 +29,26 @@ from django.http import HttpResponse, HttpResponseBadRequest
 from markdownx.utils import markdownify
 from sesame.utils import get_parameters
 
+# nh3's default allowlist is narrower than what our markdown pipeline
+# legitimately emits (MARKDOWNX_MARKDOWN_EXTENSIONS in settings/common.py):
+# it drops `target`/`referrerpolicy` on links (undoing
+# markdown_link_attr_modifier's new-tab/no-referrer config), and `id`/`class`
+# (breaking footnote anchors and code-block language classes). None of these
+# are XSS vectors once tags/handlers are stripped, so widen the allowlist
+# rather than let nh3.clean() silently mangle valid output.
+_MARKDOWN_ALLOWED_ATTRIBUTES = {
+    tag: attrs | {"id", "class"} for tag, attrs in nh3.ALLOWED_ATTRIBUTES.items()
+}
+for _tag in nh3.ALLOWED_TAGS:
+    _MARKDOWN_ALLOWED_ATTRIBUTES.setdefault(_tag, {"id", "class"})
+_MARKDOWN_ALLOWED_ATTRIBUTES["a"] = _MARKDOWN_ALLOWED_ATTRIBUTES["a"] | {
+    "target",
+    "title",
+    "referrerpolicy",
+}
+_MARKDOWN_ALLOWED_ATTRIBUTES["th"] = _MARKDOWN_ALLOWED_ATTRIBUTES["th"] | {"style"}
+_MARKDOWN_ALLOWED_ATTRIBUTES["td"] = _MARKDOWN_ALLOWED_ATTRIBUTES["td"] | {"style"}
+
 
 def render_markdown(text: AnyStr | None) -> str:
     """Render markdown to HTML, stripping any embedded/unsafe HTML.
@@ -37,7 +57,7 @@ def render_markdown(text: AnyStr | None) -> str:
     straight through, so its output is never safe to render with `|safe`
     on its own -- always sanitize it here first.
     """
-    return nh3.clean(markdownify(text or ""))
+    return nh3.clean(markdownify(text or ""), attributes=_MARKDOWN_ALLOWED_ATTRIBUTES)
 
 
 def make_site_slug(site: Site):

--- a/recoco/utils.py
+++ b/recoco/utils.py
@@ -50,7 +50,7 @@ _MARKDOWN_ALLOWED_ATTRIBUTES["th"] = _MARKDOWN_ALLOWED_ATTRIBUTES["th"] | {"styl
 _MARKDOWN_ALLOWED_ATTRIBUTES["td"] = _MARKDOWN_ALLOWED_ATTRIBUTES["td"] | {"style"}
 
 
-def render_markdown(text: AnyStr | None) -> str:
+def render_markdown(text):
     """Render markdown to HTML, stripping any embedded/unsafe HTML.
 
     `markdownx.utils.markdownify` passes raw HTML embedded in the source


### PR DESCRIPTION
Corrige le point 2 de l'audit sécurité interne.

`markdownify()` laisse passer le HTML brut embarqué, et chaque
propriété `*_rendered` (Task, TaskFollowup, Resource, Note, questions
de survey, digests de conversation) était rendue avec `|safe` —
permettant une XSS stockée via le contenu des tâches, les suivis, les
notes et les commentaires.

- Ajout de `recoco.utils.render_markdown()` = `nh3.clean(markdownify(...))`
  et remplacement de tous les appels à markdownify par cette fonction.
- Correction de `action_list_item.html` / `action_comment.html`, qui
  affichaient `followup.comment` brut (sans même passer par le
  markdown), contournant totalement l'assainissement.
- Ajout de tests de non-régression vérifiant que les payloads
  `<script>`/gestionnaires d'événements sont supprimés.