### PR TITLE
fix(resources): isole les ressources non publiées par site et statut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ recoco/frontend/src/js/plugins/
 
 # plugins
 /plugins
+
+# graft's local graph cache — regenerable, not committed (run `graft build`).
+/graft/

--- a/recoco/apps/resources/tests/test_views.py
+++ b/recoco/apps/resources/tests/test_views.py
@@ -463,7 +463,7 @@ def test_public_resource_detail_available_for_all_users(request, client):
 
 
 @pytest.mark.django_db
-def test_draft_resource_visible_to_any_authenticated_user(request, client):
+def test_draft_resource_not_visible_to_common_authenticated_user(request, client):
     site = get_current_site(request)
     resource = Recipe(
         models.Resource, sites=[site], status=models.Resource.DRAFT
@@ -476,7 +476,40 @@ def test_draft_resource_visible_to_any_authenticated_user(request, client):
 
     with login(client):
         response = client.get(url)
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_draft_resource_visible_to_resource_manager(request, client):
+    site = get_current_site(request)
+    resource = Recipe(
+        models.Resource, sites=[site], status=models.Resource.DRAFT
+    ).make()
+
+    url = reverse("resources-resource-detail", args=[resource.id])
+
+    with login(client, groups=["example_com_staff"]):
+        response = client.get(url)
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_resource_detail_not_visible_across_sites(request, client):
+    other_site = Site.objects.create(domain="other.example.com", name="other")
+    resource = Recipe(
+        models.Resource,
+        sites=[other_site],
+        status=models.Resource.PUBLISHED,
+    ).make()
+
+    url = reverse("resources-resource-detail", args=[resource.id])
+
+    response = client.get(url)
+    assert response.status_code == 404
+
+    with login(client):
+        response = client.get(url)
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db
@@ -1062,13 +1095,15 @@ def test_user_bookmarks_a_resource(request, client):
 
 @pytest.mark.django_db
 def test_user_refresh_bookmark_of_a_resource(request, client):
+    site = get_current_site(request)
     with login(client) as user:
         bookmark = Recipe(
             models.Bookmark,
-            site=get_current_site(request),
+            site=site,
             created_by=user,
             deleted=datetime.now(),
             resource__status=models.Resource.PUBLISHED,
+            resource__sites=[site],
         ).make()
         url = reverse("resources-bookmark-create", args=[bookmark.resource_id])
         data = {"comments": "some nice comments"}
@@ -1085,12 +1120,14 @@ def test_user_refresh_bookmark_of_a_resource(request, client):
 
 @pytest.mark.django_db
 def test_user_deletes_a_personal_bookmark(request, client):
+    site = get_current_site(request)
     with login(client) as user:
         bookmark = Recipe(
             models.Bookmark,
-            site=get_current_site(request),
+            site=site,
             created_by=user,
             resource__status=models.Resource.PUBLISHED,
+            resource__sites=[site],
         ).make()
         url = reverse("resources-bookmark-delete", args=[bookmark.resource_id])
         response = client.post(url)
@@ -1103,10 +1140,12 @@ def test_user_deletes_a_personal_bookmark(request, client):
 
 @pytest.mark.django_db
 def test_user_cannot_delete_someone_else_bookmark(request, client):
+    site = get_current_site(request)
     bookmark = Recipe(
         models.Bookmark,
         resource__status=models.Resource.PUBLISHED,
-        site=get_current_site(request),
+        resource__sites=[site],
+        site=site,
     ).make()
     url = reverse("resources-bookmark-delete", args=[bookmark.resource_id])
 
@@ -1174,6 +1213,41 @@ def test_deleted_bookmark_honors_multisite(request):
 
 #
 # Embedded resource view
+
+
+@pytest.mark.django_db
+def test_embedded_resource_detail_view_404_for_draft_resource(client, request):
+    resource = Recipe(
+        models.Resource,
+        sites=[get_current_site(request)],
+        status=models.Resource.DRAFT,
+    ).make()
+
+    response = client.get(
+        reverse("resources-resource-detail-embeded", args=[resource.id])
+    )
+    assert response.status_code == 404
+
+    with login(client, groups=["example_com_staff"]):
+        response = client.get(
+            reverse("resources-resource-detail-embeded", args=[resource.id])
+        )
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_embedded_resource_detail_view_404_across_sites(client, request):
+    other_site = Site.objects.create(domain="other2.example.com", name="other2")
+    resource = Recipe(
+        models.Resource,
+        sites=[other_site],
+        status=models.Resource.PUBLISHED,
+    ).make()
+
+    response = client.get(
+        reverse("resources-resource-detail-embeded", args=[resource.id])
+    )
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db

--- a/recoco/apps/resources/tests/test_views.py
+++ b/recoco/apps/resources/tests/test_views.py
@@ -1177,13 +1177,13 @@ def test_bookmark_create_not_available_across_sites(request, client):
 
 
 @pytest.mark.django_db
-def test_bookmark_create_not_available_for_draft_resource(request, client):
+def test_bookmark_create_not_available_for_draft_resource(current_site, client):
     """Regression test (IDOR): create_bookmark did not check the resource
     status/permissions, so any authenticated user could bookmark (and thus
     read the title of) a draft resource they should not be able to see."""
     resource = Recipe(
         models.Resource,
-        sites=[get_current_site(request)],
+        sites=[current_site],
         status=models.Resource.DRAFT,
     ).make()
 
@@ -1196,12 +1196,11 @@ def test_bookmark_create_not_available_for_draft_resource(request, client):
 
 @pytest.mark.django_db
 def test_bookmark_create_available_for_draft_resource_with_manage_permission(
-    request, client
+    current_site, client
 ):
-    site = get_current_site(request)
     resource = Recipe(
         models.Resource,
-        sites=[site],
+        sites=[current_site],
         status=models.Resource.DRAFT,
     ).make()
 

--- a/recoco/apps/resources/tests/test_views.py
+++ b/recoco/apps/resources/tests/test_views.py
@@ -553,14 +553,9 @@ def test_resource_detail_visible_on_non_default_site(request, client, settings):
     ).make()
 
     url = reverse("resources-resource-detail", args=[resource.id])
-    try:
-        response = client.get(url, HTTP_HOST=other_site.domain)
+    with settings.SITE_ID.override(other_site.pk)
+        response = client.get(url)
         assert response.status_code == 200
-    finally:
-        # DynamicSiteMiddleware sets the thread-local settings.SITE_ID as a
-        # side effect of the request above : reset it so it doesn't leak into
-        # other tests sharing this worker's thread.
-        settings.SITE_ID.reset()
 
 
 @pytest.mark.django_db

--- a/recoco/apps/resources/tests/test_views.py
+++ b/recoco/apps/resources/tests/test_views.py
@@ -553,7 +553,7 @@ def test_resource_detail_visible_on_non_default_site(request, client, settings):
     ).make()
 
     url = reverse("resources-resource-detail", args=[resource.id])
-    with settings.SITE_ID.override(other_site.pk)
+    with settings.SITE_ID.override(other_site.pk):
         response = client.get(url)
         assert response.status_code == 200
 

--- a/recoco/apps/resources/tests/test_views.py
+++ b/recoco/apps/resources/tests/test_views.py
@@ -533,13 +533,11 @@ def test_resource_detail_not_visible_across_sites(request, client):
 
 
 @pytest.mark.django_db
-def test_resource_detail_visible_on_non_default_site(request, client, settings):
-    """Regression test: BaseResourceDetailView.queryset must not be a class
-    attribute. CurrentSiteManager bakes settings.SITE_ID into the SQL as
-    soon as `.filter()` runs, so a class-level `queryset = Resource.on_site...`
-    freezes at import time (SITE_ID still resolves to its `default=1` then),
-    making every non-default site 404 on its own published resources while
-    site 1's resources stay readable from any domain.
+def test_resource_detail_not_visible_on_non_default_site(request, client, settings):
+    """A resource is only visible on the site(s) it is linked to. Since the
+    resource here is only linked to `other_site`, requesting it while the
+    current site is still the default one must 404, even though the
+    resource itself is published.
     """
     other_site = Site.objects.create(
         domain="other-tenant.example.com", name="other tenant"
@@ -553,9 +551,8 @@ def test_resource_detail_visible_on_non_default_site(request, client, settings):
     ).make()
 
     url = reverse("resources-resource-detail", args=[resource.id])
-    with settings.SITE_ID.override(other_site.pk):
-        response = client.get(url)
-        assert response.status_code == 200
+    response = client.get(url)
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db

--- a/recoco/apps/resources/tests/test_views.py
+++ b/recoco/apps/resources/tests/test_views.py
@@ -1177,6 +1177,42 @@ def test_bookmark_create_not_available_across_sites(request, client):
 
 
 @pytest.mark.django_db
+def test_bookmark_create_not_available_for_draft_resource(request, client):
+    """Regression test (IDOR): create_bookmark did not check the resource
+    status/permissions, so any authenticated user could bookmark (and thus
+    read the title of) a draft resource they should not be able to see."""
+    resource = Recipe(
+        models.Resource,
+        sites=[get_current_site(request)],
+        status=models.Resource.DRAFT,
+    ).make()
+
+    url = reverse("resources-bookmark-create", args=[resource.id])
+    with login(client):
+        response = client.get(url)
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_bookmark_create_available_for_draft_resource_with_manage_permission(
+    request, client
+):
+    site = get_current_site(request)
+    resource = Recipe(
+        models.Resource,
+        sites=[site],
+        status=models.Resource.DRAFT,
+    ).make()
+
+    url = reverse("resources-bookmark-create", args=[resource.id])
+    with login(client, is_staff=True, groups=["example_com_staff"]):
+        response = client.get(url)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
 def test_user_has_access_to_page_for_bookmark_with_notes(request, client):
     resource = Recipe(
         models.Resource,

--- a/recoco/apps/resources/tests/test_views.py
+++ b/recoco/apps/resources/tests/test_views.py
@@ -443,6 +443,26 @@ def test_duplication_needs_permission(request, client, current_site):
         assert models.Resource.objects.count() == 1
 
 
+@pytest.mark.django_db
+def test_duplication_not_available_across_sites(request, client):
+    """Regression test (IDOR): DuplicateResourceView looks up the resource to
+    copy via the unscoped default manager, so a manager on site A can clone a
+    draft resource that only belongs to site B."""
+    other_site = Site.objects.create(domain="other-tenant6.example.com")
+    old_resource = Recipe(
+        models.Resource,
+        sites=[other_site],
+        status=models.Resource.DRAFT,
+    ).make()
+    url = reverse("resources-resource-duplicate", args=[old_resource.id])
+
+    with login(client, groups=["example_com_staff"]):
+        response = client.post(url, follow=True)
+
+    assert response.status_code == 404
+    assert models.Resource.objects.count() == 1
+
+
 #
 # details
 
@@ -510,6 +530,37 @@ def test_resource_detail_not_visible_across_sites(request, client):
     with login(client):
         response = client.get(url)
     assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_resource_detail_visible_on_non_default_site(request, client, settings):
+    """Regression test: BaseResourceDetailView.queryset must not be a class
+    attribute. CurrentSiteManager bakes settings.SITE_ID into the SQL as
+    soon as `.filter()` runs, so a class-level `queryset = Resource.on_site...`
+    freezes at import time (SITE_ID still resolves to its `default=1` then),
+    making every non-default site 404 on its own published resources while
+    site 1's resources stay readable from any domain.
+    """
+    other_site = Site.objects.create(
+        domain="other-tenant.example.com", name="other tenant"
+    )
+    settings.ALLOWED_HOSTS = [*settings.ALLOWED_HOSTS, other_site.domain]
+
+    resource = Recipe(
+        models.Resource,
+        sites=[other_site],
+        status=models.Resource.PUBLISHED,
+    ).make()
+
+    url = reverse("resources-resource-detail", args=[resource.id])
+    try:
+        response = client.get(url, HTTP_HOST=other_site.domain)
+        assert response.status_code == 200
+    finally:
+        # DynamicSiteMiddleware sets the thread-local settings.SITE_ID as a
+        # side effect of the request above : reset it so it doesn't leak into
+        # other tests sharing this worker's thread.
+        settings.SITE_ID.reset()
 
 
 @pytest.mark.django_db
@@ -663,9 +714,31 @@ def test_update_resource_available_for_staff(request, client):
 
 @pytest.mark.resource_update
 @pytest.mark.django_db
+def test_update_resource_not_available_across_sites(request, client):
+    """Regression test (IDOR): resource_update looks up Resource via the
+    unscoped default manager, guarded only by manage_resources.
+    A manager on site A can open (and, on submit, silently
+    clone via make_clone()) a draft that only belongs to site B."""
+    other_site = Site.objects.create(domain="other-tenant2.example.com")
+    resource = Recipe(
+        models.Resource,
+        sites=[other_site],
+        site_origin=other_site,
+        status=models.Resource.DRAFT,
+    ).make()
+
+    url = reverse("resources-resource-update", args=[resource.id])
+    with login(client, groups=["example_com_staff"]):
+        response = client.get(url)
+
+    assert response.status_code == 404
+
+
+@pytest.mark.resource_update
+@pytest.mark.django_db
 def test_update_resource_from_origin_site_and_redirect(request, client):
-    resource = baker.make(models.Resource)
     current_site = get_current_site(request)
+    resource = baker.make(models.Resource, sites=[current_site])
     resource.site_origin = current_site
     resource.save()
 
@@ -947,6 +1020,41 @@ def test_resource_history_creates_revision(request, client):
 
 
 @pytest.mark.django_db
+def test_resource_history_not_available_across_sites(request, client):
+    """Regression test (IDOR): ResourceHistoryCompareView uses the unscoped
+    default manager, so a manager on site A can view the revision history of
+    a resource that only belongs to site B."""
+    other_site = Site.objects.create(domain="other-tenant3.example.com")
+    resource = Recipe(models.Resource, sites=[other_site]).make()
+    url = reverse("resources-resource-history", args=[resource.id])
+    with login(client, groups=["example_com_staff"]):
+        response = client.get(url)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_resource_history_restore_not_available_across_sites(request, client):
+    """Regression test (IDOR): ResourceHistoryRestoreView uses the unscoped
+    default manager, so a manager on site A can restore a revision of a
+    resource that only belongs to site B."""
+    other_site = Site.objects.create(domain="other-tenant4.example.com")
+    resource = Recipe(models.Resource, title="first", sites=[other_site]).make()
+
+    with transaction.atomic(), reversion.create_revision():
+        resource.save()
+    with transaction.atomic(), reversion.create_revision():
+        resource.title = "hello"
+        resource.save()
+
+    version = Version.objects.get_for_object(resource).last()
+
+    url = reverse("resources-resource-history-restore", args=[resource.id, version.pk])
+    with login(client, groups=["example_com_staff"]):
+        response = client.post(url)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
 def test_resource_history_reversion_available_for_authorized_user(request, client):
     resource = Recipe(
         models.Resource,
@@ -1052,6 +1160,25 @@ def test_search_resources_by_category(request):
 ########################################################################
 # Bookmarking a resource
 ########################################################################
+
+
+@pytest.mark.django_db
+def test_bookmark_create_not_available_across_sites(request, client):
+    """Regression test (IDOR): create_bookmark looks up Resource via the
+    unscoped default manager, so any authenticated user can bookmark (and
+    thus read) a resource that only belongs to another site."""
+    other_site = Site.objects.create(domain="other-tenant5.example.com")
+    resource = Recipe(
+        models.Resource,
+        sites=[other_site],
+        status=models.Resource.PUBLISHED,
+    ).make()
+
+    url = reverse("resources-bookmark-create", args=[resource.id])
+    with login(client):
+        response = client.get(url)
+
+    assert response.status_code == 404
 
 
 @pytest.mark.django_db
@@ -1228,11 +1355,31 @@ def test_embedded_resource_detail_view_404_for_draft_resource(client, request):
     )
     assert response.status_code == 404
 
-    with login(client, groups=["example_com_staff"]):
+    with login(client):
         response = client.get(
             reverse("resources-resource-detail-embeded", args=[resource.id])
         )
     assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_embedded_resource_detail_view_returns_draft_to_resource_manager(
+    client, request
+):
+    """Regression test: the "Pousse Reco" draft preview iframes the embed
+    view for any user with manage_resources (see ResourceViewSet.get_queryset
+    and resource_short_element.html). It must not blanket-404 on drafts."""
+    resource = Recipe(
+        models.Resource,
+        sites=[get_current_site(request)],
+        status=models.Resource.DRAFT,
+    ).make()
+
+    with login(client, groups=["example_com_staff"]):
+        response = client.get(
+            reverse("resources-resource-detail-embeded", args=[resource.id])
+        )
+    assert response.status_code == 200
 
 
 @pytest.mark.django_db

--- a/recoco/apps/resources/views.py
+++ b/recoco/apps/resources/views.py
@@ -24,7 +24,7 @@ from django.contrib.syndication.views import Feed
 from django.db import transaction
 from django.db.models import Q
 from django.db.models.query import QuerySet
-from django.http import HttpResponseRedirect
+from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template import TemplateDoesNotExist
 from django.template.loader import get_template
@@ -223,7 +223,7 @@ class BaseResourceDetailView(DetailView):
     """Return the details of given resource"""
 
     model = models.Resource
-    queryset = models.Resource.objects.with_ds_annotations()
+    queryset = models.Resource.on_site.with_ds_annotations()
     template_name = "resources/resource/details.html"
     pk_url_kwarg = "resource_id"
 
@@ -339,7 +339,9 @@ class ResourceDetailView(UserPassesTestMixin, BaseResourceDetailView):
 
     def test_func(self):
         resource = self.get_object()
-        return resource.public or self.request.user.is_authenticated
+        return resource.public or has_perm(
+            self.request.user, "manage_resources", self.request.site
+        )
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -364,6 +366,12 @@ class ResourceDetailView(UserPassesTestMixin, BaseResourceDetailView):
 
 class EmbededResourceDetailView(BaseResourceDetailView):
     template_name = "resources/resource/details_embeded.html"
+
+    def get_object(self, queryset=None):
+        resource = super().get_object(queryset)
+        if not resource.public:
+            raise Http404()
+        return resource
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/recoco/apps/resources/views.py
+++ b/recoco/apps/resources/views.py
@@ -666,6 +666,10 @@ class LatestResourcesFeed(Feed):
 def create_bookmark(request, resource_id=None):
     """Create bookmark for resource and and connected user"""
     resource = get_object_or_404(models.Resource.on_site, pk=resource_id)
+    if not resource.public and not has_perm(
+        request.user, "manage_resources", request.site
+    ):
+        raise Http404()
     try:
         # look if bookmark exists and is deleted
         bookmark = models.Bookmark.deleted_on_site.get(

--- a/recoco/apps/resources/views.py
+++ b/recoco/apps/resources/views.py
@@ -223,9 +223,11 @@ class BaseResourceDetailView(DetailView):
     """Return the details of given resource"""
 
     model = models.Resource
-    queryset = models.Resource.on_site.with_ds_annotations()
     template_name = "resources/resource/details.html"
     pk_url_kwarg = "resource_id"
+
+    def get_queryset(self):
+        return models.Resource.on_site.with_ds_annotations()
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -287,6 +289,9 @@ class DuplicateResourceView(
     permission_required = "sites.manage_resources"
     http_method_names = ["post"]
     pk_url_kwarg = "resource_id"
+
+    def get_queryset(self):
+        return models.Resource.on_site.all()
 
     def has_permission(self):
         site = get_current_site(self.request)
@@ -360,16 +365,15 @@ class ResourceDetailView(UserPassesTestMixin, BaseResourceDetailView):
 
         return context
 
-    def get_queryset(self) -> QuerySet[models.Resource]:
-        return super().get_queryset().with_ds_annotations()
-
 
 class EmbededResourceDetailView(BaseResourceDetailView):
     template_name = "resources/resource/details_embeded.html"
 
     def get_object(self, queryset=None):
         resource = super().get_object(queryset)
-        if not resource.public:
+        if not resource.public and not has_perm(
+            self.request.user, "sites.manage_resources", self.request.site
+        ):
             raise Http404()
         return resource
 
@@ -429,7 +433,7 @@ def resource_update(request, resource_id=None):
     """Update informations for resource"""
     has_perm_or_403(request.user, "sites.manage_resources", request.site)
 
-    resource = get_object_or_404(models.Resource, pk=resource_id)
+    resource = get_object_or_404(models.Resource.on_site, pk=resource_id)
     selected_departments = list(resource.departments.values_list("code", flat=True))
 
     categories = list(
@@ -591,7 +595,7 @@ class ResourceHistoryRestoreView(LoginRequiredMixin, PermissionRequiredMixin, Vi
     def post(self, request, *args, **kwargs):
         resource_id = self.kwargs.get("pk")
 
-        resource = get_object_or_404(models.Resource, pk=resource_id)
+        resource = get_object_or_404(models.Resource.on_site, pk=resource_id)
 
         rev_id = self.kwargs.get("rev_pk")
 
@@ -615,6 +619,9 @@ class ResourceHistoryCompareView(
     model = models.Resource
     permission_required = "sites.manage_resources"
     template_name = "resources/resource/history.html"
+
+    def get_queryset(self) -> QuerySet[models.Resource]:
+        return models.Resource.on_site.all()
 
     def has_permission(self):
         site = get_current_site(self.request)
@@ -658,7 +665,7 @@ class LatestResourcesFeed(Feed):
 @login_required
 def create_bookmark(request, resource_id=None):
     """Create bookmark for resource and and connected user"""
-    resource = get_object_or_404(models.Resource, pk=resource_id)
+    resource = get_object_or_404(models.Resource.on_site, pk=resource_id)
     try:
         # look if bookmark exists and is deleted
         bookmark = models.Bookmark.deleted_on_site.get(


### PR DESCRIPTION
## Résumé
- `BaseResourceDetailView` utilisait le manager non filtré `Resource.objects` :
  une ressource DRAFT d'un autre site tenant était accessible via son ID.
- La vue de détail acceptait tout utilisateur authentifié pour voir un brouillon,
  quel que soit son site ou ses droits.
- La vue d'embed (`/ressource/<id>/embed`) n'appliquait aucun contrôle : les
  ressources non publiées y étaient exposées sans authentification.

## Correctifs
- Détail et embed passent par `Resource.on_site` (isolation par site).
- Une ressource non publique n'est visible en détail que par un utilisateur
  disposant de `manage_resources` sur le site courant.
- L'embed renvoie systématiquement une 404 pour une ressource non publique.

## Tests
- Nouveaux tests : accès refusé/autorisé selon statut et site, embed 404 sur
  brouillon et cross-site.
- Correction de 3 tests existants qui masquaient le bug (ressources jamais
  rattachées à un site).