### PR TITLE
fix(resource): corrige l'IDOR cross-tenant sur l'édition/duplication/suppression/restauration de ressources

### DIFF
--- a/recoco/apps/resources/tests/test_views.py
+++ b/recoco/apps/resources/tests/test_views.py
@@ -634,6 +634,7 @@ def test_update_resource_from_origin_site_and_redirect(request, client):
     resource = baker.make(models.Resource)
     current_site = get_current_site(request)
     resource.site_origin = current_site
+    resource.sites.add(current_site)
     resource.save()
 
     previous_update = resource.updated_on
@@ -780,6 +781,62 @@ def test_update_resource_from_non_origin_site_and_redirect(request, client):
     assert new_resource.site_origin == current_site
 
 
+@pytest.mark.resource_update
+@pytest.mark.django_db
+def test_update_resource_cross_tenant_is_forbidden(request, client):
+    """A resource manager on site A must not be able to edit a resource that
+    only belongs to site B, even though `sites.manage_resources` is granted
+    at the site level."""
+    other_site = baker.make(Site)
+    resource = baker.make(models.Resource, sites=[other_site])
+
+    url = reverse("resources-resource-update", args=[resource.id])
+
+    with login(client, groups=["example_com_staff"]):
+        response = client.get(url)
+
+    assert response.status_code == 404
+
+    data = {
+        "title": "hacked title",
+        "subtitle": "a sub title",
+        "status": 0,
+        "summary": "a summary",
+        "tags": "#tag",
+        "content": "cross tenant content injection",
+        "support_orga": "Attacker Corp",
+    }
+
+    with login(client, groups=["example_com_staff"], username="test2"):
+        response = client.post(url, data=data)
+
+    assert response.status_code == 404
+
+    resource.refresh_from_db()
+    assert resource.content != data["content"]
+
+
+########################################################################
+# duplicate
+########################################################################
+
+
+@pytest.mark.django_db
+def test_duplicate_resource_cross_tenant_is_forbidden(request, client):
+    """A resource manager on site A must not be able to duplicate a resource
+    that only belongs to site B into site A."""
+    other_site = baker.make(Site)
+    resource = baker.make(models.Resource, sites=[other_site])
+
+    url = reverse("resources-resource-duplicate", args=[resource.id])
+
+    with login(client, groups=["example_com_staff"]):
+        response = client.post(url)
+
+    assert response.status_code == 404
+    assert models.Resource.objects.count() == 1
+
+
 ########################################################################
 # delete
 ########################################################################
@@ -857,6 +914,30 @@ def test_delete_resource_non_shared_and_redirect(client, request):
     resource.refresh_from_db()
     assert resource.sites.count() == 0
     assert resource.deleted is not None
+
+
+@pytest.mark.resource_delete
+@pytest.mark.django_db
+def test_delete_resource_cross_tenant_is_forbidden(client, request):
+    """A resource manager on site A must not be able to delete a resource
+    that only belongs to site B."""
+    other_site = baker.make(Site)
+    resource = baker.make(models.Resource, sites=[other_site])
+
+    url = reverse("resources-resource-delete", args=(resource.pk,))
+    with login(client, groups=["example_com_staff"]):
+        response = client.get(url)
+
+    assert response.status_code == 404
+
+    with login(client, groups=["example_com_staff"], username="test2"):
+        response = client.post(url)
+
+    assert response.status_code == 404
+
+    resource.refresh_from_db()
+    assert resource.deleted is None
+    assert other_site in resource.sites.all()
 
 
 #
@@ -941,6 +1022,32 @@ def test_resource_history_reversion_available_for_authorized_user(request, clien
 
     assert resource.title == "first"
     assert Version.objects.get_for_object(resource).count() == 3
+
+
+@pytest.mark.django_db
+def test_resource_history_restore_cross_tenant_is_forbidden(request, client):
+    """A resource manager on site A must not be able to revert a revision on
+    a resource that only belongs to site B."""
+    other_site = baker.make(Site)
+    resource = Recipe(models.Resource, title="first", sites=[other_site]).make()
+
+    with transaction.atomic(), reversion.create_revision():
+        resource.save()
+
+    with transaction.atomic(), reversion.create_revision():
+        resource.title = "hello"
+        resource.save()
+
+    version = Version.objects.get_for_object(resource).last()
+
+    url = reverse("resources-resource-history-restore", args=[resource.id, version.pk])
+    with login(client, groups=["example_com_staff"]):
+        response = client.post(url)
+
+    assert response.status_code == 404
+
+    resource.refresh_from_db()
+    assert resource.title == "hello"
 
 
 ########################################################################

--- a/recoco/apps/resources/tests/test_views.py
+++ b/recoco/apps/resources/tests/test_views.py
@@ -443,6 +443,22 @@ def test_duplication_needs_permission(request, client, current_site):
         assert models.Resource.objects.count() == 1
 
 
+@pytest.mark.django_db
+def test_duplicate_resource_cross_tenant_is_forbidden(request, client):
+    """A resource manager on site A must not be able to duplicate a resource
+    that only belongs to site B into site A."""
+    other_site = baker.make(Site)
+    resource = baker.make(models.Resource, sites=[other_site])
+
+    url = reverse("resources-resource-duplicate", args=[resource.id])
+
+    with login(client, groups=["example_com_staff"]):
+        response = client.post(url)
+
+    assert response.status_code == 404
+    assert models.Resource.objects.count() == 1
+
+
 #
 # details
 
@@ -789,6 +805,7 @@ def test_update_resource_cross_tenant_is_forbidden(request, client):
     at the site level."""
     other_site = baker.make(Site)
     resource = baker.make(models.Resource, sites=[other_site])
+    original_content = resource.content
 
     url = reverse("resources-resource-update", args=[resource.id])
 
@@ -813,28 +830,7 @@ def test_update_resource_cross_tenant_is_forbidden(request, client):
     assert response.status_code == 404
 
     resource.refresh_from_db()
-    assert resource.content != data["content"]
-
-
-########################################################################
-# duplicate
-########################################################################
-
-
-@pytest.mark.django_db
-def test_duplicate_resource_cross_tenant_is_forbidden(request, client):
-    """A resource manager on site A must not be able to duplicate a resource
-    that only belongs to site B into site A."""
-    other_site = baker.make(Site)
-    resource = baker.make(models.Resource, sites=[other_site])
-
-    url = reverse("resources-resource-duplicate", args=[resource.id])
-
-    with login(client, groups=["example_com_staff"]):
-        response = client.post(url)
-
-    assert response.status_code == 404
-    assert models.Resource.objects.count() == 1
+    assert resource.content == original_content
 
 
 ########################################################################

--- a/recoco/apps/resources/views.py
+++ b/recoco/apps/resources/views.py
@@ -292,6 +292,9 @@ class DuplicateResourceView(
         site = get_current_site(self.request)
         return self.request.user.has_perm(self.permission_required, site)
 
+    def get_queryset(self):
+        return models.Resource.on_site.all()
+
     def post(self, request, *args, **kwargs):
         current_site = get_current_site(request)
         resource_to_copy = self.get_object()
@@ -386,6 +389,9 @@ class ResourceDeleteView(UserPassesTestMixin, DeleteView):
     success_url = reverse_lazy("crm-resource-list")
     pk_url_kwarg = "resource_id"
 
+    def get_queryset(self):
+        return models.Resource.on_site.all()
+
     def form_valid(self, form):
         """
         Dereference the current site from the resource.
@@ -421,7 +427,7 @@ def resource_update(request, resource_id=None):
     """Update informations for resource"""
     has_perm_or_403(request.user, "sites.manage_resources", request.site)
 
-    resource = get_object_or_404(models.Resource, pk=resource_id)
+    resource = get_object_or_404(models.Resource.on_site, pk=resource_id)
     selected_departments = list(resource.departments.values_list("code", flat=True))
 
     categories = list(
@@ -583,7 +589,7 @@ class ResourceHistoryRestoreView(LoginRequiredMixin, PermissionRequiredMixin, Vi
     def post(self, request, *args, **kwargs):
         resource_id = self.kwargs.get("pk")
 
-        resource = get_object_or_404(models.Resource, pk=resource_id)
+        resource = get_object_or_404(models.Resource.on_site, pk=resource_id)
 
         rev_id = self.kwargs.get("rev_pk")
 


### PR DESCRIPTION
**Contexte** : audit de sécurité 2026-09-04, item 8 (Critical).

**Problème** : `resource_update`, `ResourceDeleteView`, `DuplicateResourceView` et `ResourceHistoryRestoreView` autorisent via la permission `sites.manage_resources` (niveau site) mais récupèrent la ressource cible via le manager non filtré (`Resource.objects` / queryset par défaut), sans vérifier qu'elle appartient bien à `request.site`.

**Exploit** : un gestionnaire de ressources du site A pouvait, en devinant l'ID, éditer, dupliquer, supprimer ou restaurer une révision d'une ressource appartenant exclusivement au site B : aucune relation requise entre l'utilisateur et le site B.

**Correctif** : les quatre lookups utilisent désormais `Resource.on_site` (manager déjà filtré par site courant), comme c'est déjà le cas ailleurs dans le fichier.

**Tests** : 4 tests de non-régression ajoutés, chacun crée une ressource sur un site B et vérifie qu'un manager du site A reçoit un `404` (au lieu de `200`/`302` avant le fix) sur les 4 actions concernées.

## Plan de test
- [x] `pytest recoco/apps/resources/` → 105 passed
- [x] Tests ajoutés échouent sur le code vulnérable, passent après le fix