### PR TITLE
 fix(projects): corrige l'IDOR sur la suppression/épinglage de documents

### DIFF
--- a/recoco/apps/projects/tests/test_administration.py
+++ b/recoco/apps/projects/tests/test_administration.py
@@ -787,8 +787,8 @@ def test_staff_can_resend_collaborator_invitation(request, client, mocker, proje
 
 @pytest.mark.django_db
 def test_revoke_invite_cross_project_is_forbidden(request, client, project):
-    # a manage_collaborators grant on one project must not let you revoke
-    # (delete) an invite that belongs to a different project
+    """A manage_collaborators grant on one project must not let you revoke
+    (delete) an invite that belongs to a different project"""
     other_project = Recipe(
         projects_models.Project, sites=[get_current_site(request)]
     ).make()

--- a/recoco/apps/projects/tests/test_administration.py
+++ b/recoco/apps/projects/tests/test_administration.py
@@ -786,6 +786,35 @@ def test_staff_can_resend_collaborator_invitation(request, client, mocker, proje
 
 
 @pytest.mark.django_db
+def test_revoke_invite_cross_project_is_forbidden(request, client, project):
+    # a manage_collaborators grant on one project must not let you revoke
+    # (delete) an invite that belongs to a different project
+    other_project = Recipe(
+        projects_models.Project, sites=[get_current_site(request)]
+    ).make()
+
+    invite = baker.make(
+        invites_models.Invite,
+        site=get_current_site(request),
+        project=other_project,
+        role="COLLABORATOR",
+        email="invited@party.com",
+    )
+
+    with login(client) as user:
+        assign_collaborator(user, project, is_owner=True)
+
+        url = reverse(
+            "projects-project-access-revoke-invite",
+            args=[project.id, invite.pk],
+        )
+        response = client.post(url)
+
+    assert response.status_code == 404
+    assert invites_models.Invite.objects.filter(pk=invite.pk).exists()
+
+
+@pytest.mark.django_db
 def test_set_project_active_date_is_saved(client, project_ready, current_site):
     project_ready.inactive_since = timezone.make_aware(datetime(2024, 1, 1))
     project_ready.save()

--- a/recoco/apps/projects/tests/test_documents.py
+++ b/recoco/apps/projects/tests/test_documents.py
@@ -328,6 +328,61 @@ def test_delete_document_not_available_for_others(client, request, project):
 
 
 @pytest.mark.django_db
+def test_delete_document_cross_project_is_forbidden(request, client, project):
+    """A collaborator managing documents on their own project must not be
+    able to delete a document belonging to a different, unrelated project,
+    even one they uploaded themselves."""
+    other_project = Recipe(models.Project, sites=[get_current_site(request)]).make()
+
+    with login(client) as user:
+        assign_collaborator(user, project, is_owner=True)
+
+        document = baker.make(
+            models.Document,
+            uploaded_by=user,
+            project=other_project,
+            the_link="http://yo",
+            site=get_current_site(request),
+        )
+
+        url = reverse(
+            "projects-documents-delete-document", args=[project.id, document.id]
+        )
+        response = client.post(url)
+
+    assert response.status_code == 404
+
+    document.refresh_from_db()
+    assert document.deleted is None
+
+
+@pytest.mark.django_db
+def test_pin_document_cross_project_is_forbidden(request, client, project):
+    """A collaborator managing documents on their own project must not be
+    able to pin/unpin a document belonging to a different, unrelated
+    project."""
+    other_project = Recipe(models.Project, sites=[get_current_site(request)]).make()
+    document = baker.make(
+        models.Document,
+        project=other_project,
+        the_link="http://yo",
+        site=get_current_site(request),
+        uploaded_by__username="other",
+    )
+
+    with login(client) as user:
+        assign_collaborator(user, project, is_owner=True)
+
+        url = reverse("projects-documents-pin-unpin", args=[project.id, document.pk])
+        response = client.post(url)
+
+    assert response.status_code == 404
+
+    document.refresh_from_db()
+    assert document.pinned is False
+
+
+@pytest.mark.django_db
 def test_project_pin_document(request, client, project):
     with login(client) as user:
         document = baker.make(

--- a/recoco/apps/projects/tests/test_documents.py
+++ b/recoco/apps/projects/tests/test_documents.py
@@ -383,6 +383,52 @@ def test_pin_document_cross_project_is_forbidden(request, client, project):
 
 
 @pytest.mark.django_db
+def test_delete_document_permission_checked_before_document_lookup(
+    request, client, project
+):
+    # permission check must run before the document lookup, otherwise a user
+    # with no rights on the project could tell from the status code (403 vs
+    # 404) whether a given document id belongs to another project or not
+    other_project = Recipe(models.Project, sites=[get_current_site(request)]).make()
+    document = baker.make(
+        models.Document,
+        project=other_project,
+        the_link="http://yo",
+        site=get_current_site(request),
+        uploaded_by__username="other",
+    )
+
+    with login(client):
+        url = reverse(
+            "projects-documents-delete-document", args=[project.id, document.id]
+        )
+        response = client.post(url)
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_pin_document_permission_checked_before_document_lookup(
+    request, client, project
+):
+    # same oracle check as above, for pin/unpin
+    other_project = Recipe(models.Project, sites=[get_current_site(request)]).make()
+    document = baker.make(
+        models.Document,
+        project=other_project,
+        the_link="http://yo",
+        site=get_current_site(request),
+        uploaded_by__username="other",
+    )
+
+    with login(client):
+        url = reverse("projects-documents-pin-unpin", args=[project.id, document.pk])
+        response = client.post(url)
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
 def test_project_pin_document(request, client, project):
     with login(client) as user:
         document = baker.make(

--- a/recoco/apps/projects/tests/test_documents.py
+++ b/recoco/apps/projects/tests/test_documents.py
@@ -386,9 +386,9 @@ def test_pin_document_cross_project_is_forbidden(request, client, project):
 def test_delete_document_permission_checked_before_document_lookup(
     request, client, project
 ):
-    # permission check must run before the document lookup, otherwise a user
-    # with no rights on the project could tell from the status code (403 vs
-    # 404) whether a given document id belongs to another project or not
+    """Permission check must run before the document lookup, otherwise a user
+    with no rights on the project could tell from the status code (403 vs
+    404) whether a given document id belongs to another project or not"""
     other_project = Recipe(models.Project, sites=[get_current_site(request)]).make()
     document = baker.make(
         models.Document,
@@ -411,7 +411,7 @@ def test_delete_document_permission_checked_before_document_lookup(
 def test_pin_document_permission_checked_before_document_lookup(
     request, client, project
 ):
-    # same oracle check as above, for pin/unpin
+    """same oracle check as above^, for pin/unpin"""
     other_project = Recipe(models.Project, sites=[get_current_site(request)]).make()
     document = baker.make(
         models.Document,

--- a/recoco/apps/projects/views/administration.py
+++ b/recoco/apps/projects/views/administration.py
@@ -243,7 +243,9 @@ def access_revoke_invite(request, project_id, invite_id):
     """Revoke an invitation for a collectivity member"""
     project = get_object_or_404(models.Project, sites=request.site, pk=project_id)
 
-    invite = get_object_or_404(invites_models.Invite, pk=invite_id, accepted_on=None)
+    invite = get_object_or_404(
+        invites_models.Invite, pk=invite_id, project=project, accepted_on=None
+    )
 
     if invite.role == "SWITCHTENDER":
         has_perm_or_403(request.user, "manage_advisors", project)

--- a/recoco/apps/projects/views/documents.py
+++ b/recoco/apps/projects/views/documents.py
@@ -144,8 +144,8 @@ def document_upload(request, project_id):
 @login_required
 def document_delete(request, project_id, document_id):
     """Delete a document for a project"""
-    project = get_object_or_404(models.Project, pk=project_id)
-    document = get_object_or_404(models.Document, pk=document_id)
+    project = get_object_or_404(models.Project, pk=project_id, sites=request.site)
+    document = get_object_or_404(models.Document, pk=document_id, project=project)
 
     has_perm_or_403(request.user, "manage_documents", project)
 
@@ -166,8 +166,8 @@ def document_delete(request, project_id, document_id):
 @login_required
 def document_pin_unpin(request, project_id, document_id):
     """Delete a document for a project"""
-    project = get_object_or_404(models.Project, pk=project_id)
-    document = get_object_or_404(models.Document, pk=document_id)
+    project = get_object_or_404(models.Project, pk=project_id, sites=request.site)
+    document = get_object_or_404(models.Document, pk=document_id, project=project)
 
     has_perm_or_403(request.user, "manage_documents", project)
 

--- a/recoco/apps/projects/views/documents.py
+++ b/recoco/apps/projects/views/documents.py
@@ -145,9 +145,9 @@ def document_upload(request, project_id):
 def document_delete(request, project_id, document_id):
     """Delete a document for a project"""
     project = get_object_or_404(models.Project, pk=project_id, sites=request.site)
-    document = get_object_or_404(models.Document, pk=document_id, project=project)
-
     has_perm_or_403(request.user, "manage_documents", project)
+
+    document = get_object_or_404(models.Document, pk=document_id, project=project)
 
     if request.method == "POST":
         if document.uploaded_by != request.user:
@@ -167,9 +167,9 @@ def document_delete(request, project_id, document_id):
 def document_pin_unpin(request, project_id, document_id):
     """Delete a document for a project"""
     project = get_object_or_404(models.Project, pk=project_id, sites=request.site)
-    document = get_object_or_404(models.Document, pk=document_id, project=project)
-
     has_perm_or_403(request.user, "manage_documents", project)
+
+    document = get_object_or_404(models.Document, pk=document_id, project=project)
 
     if request.method == "POST":
         document.pinned = not document.pinned


### PR DESCRIPTION
**Contexte** : audit de sécurité 2026-09-04, finding 9 (Medium).

**Problème** : `document_delete` et `document_pin_unpin` vérifient la permission `manage_documents` sur le `project` de l'URL, mais récupèrent le `document` indépendamment, par simple `pk`, sans lien avec ce projet. Le projet lui-même n'était pas non plus filtré par `request.site`.

**Exploit** : un utilisateur ayant `manage_documents` sur son propre projet pouvait, en devinant un `document_id`, épingler/désépingler n'importe quel document d'un projet totalement différent — et le supprimer (soft-delete) s'il en était l'auteur, même sans aucun droit sur le projet auquel ce document appartient réellement.

**Correctif** : le document est désormais récupéré via `get_object_or_404(Document, pk=document_id, project=project)`, et le projet est filtré par `sites=request.site`.

**Tests** : 2 tests de non-régression ajoutés (delete, pin/unpin), chacun crée un document sur un projet B distinct et vérifie qu'un gestionnaire de documents du projet A reçoit un `404` (au lieu de `302`/succès avant le fix).

## Plan de test
- [x] `pytest recoco/apps/projects/tests/test_documents.py` → 19 passed
- [x] Tests ajoutés échouent sur le code vulnérable, passent après le fix