### PR TITLE
fix(projects): cloisonner par site l'adhésion conseiller/observateur et la suppression de projet

### DIFF
--- a/recoco/apps/projects/tests/test_projects.py
+++ b/recoco/apps/projects/tests/test_projects.py
@@ -593,6 +593,24 @@ def test_delete_project_and_redirect(request, client):
 
 
 @pytest.mark.django_db
+def test_delete_project_forbidden_for_project_on_other_site(request, client):
+    """A moderator holding delete_projects on their own site must not be
+    able to delete a project that only exists on a different tenant
+    site."""
+    other_site = Recipe(sites.Site, domain="other.site").make()
+    project = Recipe(models.Project, sites=[other_site]).make()
+    url = reverse("projects-project-delete", args=[project.id])
+
+    with login(client, groups=["example_com_staff"]):
+        response = client.post(url)
+
+    assert response.status_code == 404
+
+    project.refresh_from_db()
+    assert not project.deleted
+
+
+@pytest.mark.django_db
 def test_general_notifications_are_consumed_on_project_overview(request, client):
     current_site = get_current_site(request)
 
@@ -777,6 +795,46 @@ def test_switchtender_leaves_project(request, client, make_project):
 
     assert response.status_code == 302
     assert project.switchtenders.count() == 0
+
+
+@pytest.mark.django_db
+def test_switchtender_join_forbidden_for_project_on_other_site(
+    request, client, make_project
+):
+    """A national advisor authenticated on their own site must not be able
+    to join as switchtender a project that only exists on a different
+    tenant site."""
+    other_site = Recipe(sites.Site, domain="other.site").make()
+    commune = Recipe(geomatics.Commune).make()
+    project = make_project(site=other_site, commune=commune)
+
+    url = reverse("projects-project-switchtender-join", args=[project.id])
+    with login(client, groups=["example_com_advisor"]) as user:
+        response = client.post(url)
+
+    assert response.status_code == 404
+    assert project.switchtender_sites.count() == 0
+    assert user not in project.switchtenders.all()
+
+
+@pytest.mark.django_db
+def test_observer_join_forbidden_for_project_on_other_site(
+    request, client, make_project
+):
+    """A national advisor authenticated on their own site must not be able
+    to join as observer a project that only exists on a different tenant
+    site."""
+    other_site = Recipe(sites.Site, domain="other.site").make()
+    commune = Recipe(geomatics.Commune).make()
+    project = make_project(site=other_site, commune=commune)
+
+    url = reverse("projects-project-observer-join", args=[project.id])
+    with login(client, groups=["example_com_advisor"]) as user:
+        response = client.post(url)
+
+    assert response.status_code == 404
+    assert project.switchtender_sites.count() == 0
+    assert user not in project.switchtenders.all()
 
 
 @pytest.mark.django_db

--- a/recoco/apps/projects/tests/test_projects.py
+++ b/recoco/apps/projects/tests/test_projects.py
@@ -746,14 +746,6 @@ def test_switchtender_joins_project(request, client, make_project):
     current_site = get_current_site(request)
 
     commune = Recipe(geomatics.Commune).make()
-    dept = Recipe(geomatics.Department).make()
-    Recipe(
-        task_models.TaskRecommendation,
-        condition="",
-        departments=[
-            dept,
-        ],
-    ).make()
     project = make_project(site=current_site, commune=commune)
 
     url = reverse("projects-project-switchtender-join", args=[project.id])
@@ -771,14 +763,6 @@ def test_switchtender_joins_project(request, client, make_project):
 @pytest.mark.django_db
 def test_switchtender_leaves_project(request, client, make_project):
     commune = Recipe(geomatics.Commune).make()
-    dept = Recipe(geomatics.Department).make()
-    Recipe(
-        task_models.TaskRecommendation,
-        condition="",
-        departments=[
-            dept,
-        ],
-    ).make()
     site = get_current_site(request)
     project = make_project(site=site, commune=commune)
 
@@ -842,18 +826,9 @@ def test_advisor_joins_trigger_notification_to_all(request, client, make_project
     current_site = get_current_site(request)
 
     commune = Recipe(geomatics.Commune).make()
-    dept = Recipe(geomatics.Department).make()
 
     collaborator = baker.make(auth.User)
     advisor = baker.make(auth.User)
-
-    baker.make(
-        task_models.TaskRecommendation,
-        condition="",
-        departments=[
-            dept,
-        ],
-    )
 
     project = make_project(site=current_site, status="READY", commune=commune)
 
@@ -876,17 +851,9 @@ def test_switchtender_joins_and_leaves_on_the_same_12h_should_not_notify(
     current_site = get_current_site(request)
 
     commune = Recipe(geomatics.Commune).make()
-    dept = Recipe(geomatics.Department).make()
 
     membership = baker.make(models.ProjectMember, is_owner=True)
 
-    Recipe(
-        task_models.TaskRecommendation,
-        condition="",
-        departments=[
-            dept,
-        ],
-    ).make()
     project = make_project(
         status="BLAH",
         projectmember_set=[membership],

--- a/recoco/apps/projects/views/__init__.py
+++ b/recoco/apps/projects/views/__init__.py
@@ -488,7 +488,7 @@ def project_maplist(request):
 def project_switchtender_join(request, project_id=None):
     """Join as switchtender"""
 
-    project = get_object_or_404(models.Project, pk=project_id)
+    project = get_object_or_404(models.Project, pk=project_id, sites=request.site)
 
     if not can_administrate_project(project, request.user):
         is_regional_actor_for_project_or_403(
@@ -519,7 +519,7 @@ def project_switchtender_join(request, project_id=None):
 @login_required
 def project_observer_join(request, project_id=None):
     """Join as observer"""
-    project = get_object_or_404(models.Project, pk=project_id)
+    project = get_object_or_404(models.Project, pk=project_id, sites=request.site)
 
     if not can_administrate_project(project, request.user):
         is_regional_actor_for_project_or_403(
@@ -580,7 +580,7 @@ def project_delete(request, project_id=None):
     """Mark project as deleted in the DB"""
     has_perm_or_403(request.user, "sites.delete_projects", request.site)
 
-    project = get_object_or_404(models.Project, pk=project_id)
+    project = get_object_or_404(models.Project, pk=project_id, sites=request.site)
     if request.method == "POST":
         project.deleted = project.updated_on = timezone.now()
         project.save()


### PR DESCRIPTION
## Résumé

Corrige le point n°11 de l'audit de sécurité : trois vues récupéraient le `Project` cible par simple `pk`, sans vérifier qu'il appartenait bien au site courant (`request.site`).

- `project_switchtender_join` / `project_observer_join` : l'autorisation repose sur un contrôle par département, contournable par tout conseiller « national » (sans département renseigné), qui pouvait ainsi rejoindre un projet existant uniquement sur un autre site.
- `project_delete` : l'autorisation repose sur une permission de niveau site (`sites.delete_projects`), sans vérifier que le projet ciblé appartient à ce site.

**Impact avant correctif** : un conseiller national authentifié sur son propre site pouvait s'assigner comme conseiller/observateur sur un projet d'un autre tenant, et un modérateur pouvait supprimer un projet n'existant que sur un autre site.

**Correctif** : ajout du filtre `sites=request.site` sur les trois `get_object_or_404`, à l'image du pattern déjà utilisé dans `documents.py`.

## Tests

- Ajout de 3 tests de régression dans `test_projects.py`, rouges avant le correctif (302 au lieu de 404), verts après.
- Suite complète `recoco/apps/projects/tests/` : 302 passés (1 échec préexistant sans lien, lié à une table de plugin absente en local).

## Plan de test
- [x] `test_switchtender_join_forbidden_for_project_on_other_site`
- [x] `test_observer_join_forbidden_for_project_on_other_site`
- [x] `test_delete_project_forbidden_for_project_on_other_site`
- [x] Suite complète `recoco/apps/projects/tests/`