### PR TITLE
fix(communication): neutralise l'injection de template Brevo dans les params email

### DIFF
--- a/recoco/apps/communication/brevo.py
+++ b/recoco/apps/communication/brevo.py
@@ -10,6 +10,24 @@ from sib_api_v3_sdk.rest import ApiException
 logger = logging.getLogger("main")
 
 
+def sanitize_brevo_params(value):
+    """Neutralize Brevo's `{{ }}` template syntax in outgoing params.
+
+    User-controlled strings (note content, comments, names, etc.) can reach
+    Brevo's own template renderer verbatim. A payload like `{{7*7}}` would
+    then be evaluated by Brevo, not us (a Brevo-side SSTI). Breaking up any
+    double-brace sequence with a zero-width space keeps the text visually
+    unchanged while stopping Brevo from recognizing it as a template tag.
+    """
+    if isinstance(value, str):
+        return value.replace("{{", "{​{").replace("}}", "}​}")
+    if isinstance(value, dict):
+        return {k: sanitize_brevo_params(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [sanitize_brevo_params(v) for v in value]
+    return value
+
+
 class Brevo:
     def __init__(self):
         self.configuration = brevo_sdk.Configuration()
@@ -76,7 +94,7 @@ class Brevo:
             send_smtp_email = brevo_sdk.SendSmtpEmail(
                 template_id=template_id,
                 to=send_to,
-                params=params,
+                params=sanitize_brevo_params(params),
                 sender=sender,
             )
 

--- a/recoco/apps/communication/brevo.py
+++ b/recoco/apps/communication/brevo.py
@@ -10,19 +10,48 @@ from sib_api_v3_sdk.rest import ApiException
 logger = logging.getLogger("main")
 
 
+_TEMPLATE_DELIMITERS = ("{{", "}}", "{%", "%}", "{#", "#}")
+
+# Deliberately a visible space: an invisible separator silently stops working
+# if any stage of Brevo's pipeline strips or normalizes zero-width characters.
+_DELIMITER_SEPARATOR = " "
+
+
+def _break_template_delimiters(text):
+    """Separate the two halves of every Django template delimiter.
+
+    A single non-overlapping replace pass can leave a delimiter behind on
+    overlapping/odd-length brace runs (e.g. "{{{7*7}}}" still contains "{{"
+    after one pass), so this loops until no known delimiter remains.
+    """
+    previous = None
+    while previous != text:
+        previous = text
+        for pair in _TEMPLATE_DELIMITERS:
+            text = text.replace(pair, f"{pair[0]}{_DELIMITER_SEPARATOR}{pair[1]}")
+    return text
+
+
 def sanitize_brevo_params(value):
-    """Neutralize Brevo's `{{ }}` template syntax in outgoing params.
+    """Neutralize Brevo/Django template syntax in outgoing params.
 
     User-controlled strings (note content, comments, names, etc.) can reach
-    Brevo's own template renderer verbatim. A payload like `{{7*7}}` would
-    then be evaluated by Brevo, not us (a Brevo-side SSTI). Breaking up any
-    double-brace sequence with a zero-width space keeps the text visually
-    unchanged while stopping Brevo from recognizing it as a template tag.
+    Brevo's own template renderer verbatim. Brevo's engine is Django-based,
+    so `{{ }}`, `{% %}` and `{# #}` are all live syntax; a payload like
+    `{{7*7}}` would be evaluated by Brevo, not us (a Brevo-side SSTI).
+    Inserting a space inside any such delimiter stops Brevo from
+    recognizing it as a template tag, at the cost of a visible space in the
+    rare case where a user legitimately wrote one of those sequences.
     """
     if isinstance(value, str):
-        return value.replace("{{", "{​{").replace("}}", "}​}")
+        return _break_template_delimiters(value)
     if isinstance(value, dict):
-        return {k: sanitize_brevo_params(v) for k, v in value.items()}
+        return {
+            (_break_template_delimiters(k) if isinstance(k, str) else k): (
+                sanitize_brevo_params(v)
+            )
+            for k, v in value.items()
+        }
     if isinstance(value, (list, tuple)):
         return [sanitize_brevo_params(v) for v in value]
     return value

--- a/recoco/apps/communication/tests/test_brevo.py
+++ b/recoco/apps/communication/tests/test_brevo.py
@@ -11,7 +11,7 @@ import pytest
 from django.conf import settings
 from django.core.exceptions import ValidationError
 
-from ..brevo import Brevo
+from ..brevo import Brevo, sanitize_brevo_params
 
 
 def test_brevo_send_email_to_unique_recipient(mocker, client):
@@ -104,3 +104,40 @@ def test_brevo_send_email_checks_address_format(mocker, client):
             recipients={"name": "Bob", "email": "bob@.com"},
             params={"p1": "v1"},
         )
+
+
+def test_sanitize_brevo_params_breaks_template_syntax():
+    assert "{{" not in sanitize_brevo_params("{{7*7}}")
+    assert "}}" not in sanitize_brevo_params("{{7*7}}")
+
+
+def test_sanitize_brevo_params_recurses_into_nested_structures():
+    sanitized = sanitize_brevo_params(
+        {
+            "message": "{{7*7}}",
+            "sender": {"first_name": "{{config}}"},
+            "items": ["{{oops}}", 42, None],
+        }
+    )
+
+    assert "{{" not in sanitized["message"]
+    assert "{{" not in sanitized["sender"]["first_name"]
+    assert "{{" not in sanitized["items"][0]
+    assert sanitized["items"][1] == 42
+    assert sanitized["items"][2] is None
+
+
+def test_brevo_send_email_neutralizes_ssti_payload_in_params(mocker, client):
+    brevo = Brevo()
+
+    mocker.patch("sib_api_v3_sdk.TransactionalEmailsApi.send_transac_email")
+
+    brevo.send_email(
+        template_id=1,
+        recipients={"name": "Bob", "email": "bob@example.com"},
+        params={"message": "{{7*7}}"},
+    )
+
+    send_smtp_email = brevo.api_instance.send_transac_email.call_args.args[0]
+    assert "{{" not in send_smtp_email.params["message"]
+    assert "}}" not in send_smtp_email.params["message"]

--- a/recoco/apps/communication/tests/test_brevo.py
+++ b/recoco/apps/communication/tests/test_brevo.py
@@ -107,8 +107,32 @@ def test_brevo_send_email_checks_address_format(mocker, client):
 
 
 def test_sanitize_brevo_params_breaks_template_syntax():
-    assert "{{" not in sanitize_brevo_params("{{7*7}}")
-    assert "}}" not in sanitize_brevo_params("{{7*7}}")
+    sanitized = sanitize_brevo_params("{{7*7}}")
+
+    assert "{{" not in sanitized
+    assert "}}" not in sanitized
+    assert sanitized == "{ {7*7} }"
+
+
+def test_sanitize_brevo_params_breaks_overlapping_brace_runs():
+    sanitized = sanitize_brevo_params("{{{7*7}}}")
+    assert "{{" not in sanitized
+    assert "}}" not in sanitized
+
+
+def test_sanitize_brevo_params_breaks_tag_and_comment_syntax():
+    sanitized_tag = sanitize_brevo_params("{% for x in y %}")
+    assert "{%" not in sanitized_tag
+    assert "%}" not in sanitized_tag
+
+    sanitized_comment = sanitize_brevo_params("{# secret #}")
+    assert "{#" not in sanitized_comment
+    assert "#}" not in sanitized_comment
+
+
+def test_sanitize_brevo_params_sanitizes_dict_keys():
+    sanitized = sanitize_brevo_params({"{{7*7}}": "value"})
+    assert not any("{{" in key for key in sanitized)
 
 
 def test_sanitize_brevo_params_recurses_into_nested_structures():


### PR DESCRIPTION
## Contexte

Un rapport de bug bounty a montré qu'un payload comme `{{7*7}}` saisi par un utilisateur (note, commentaire, message d'invitation, nom de projet...) était transmis tel quel dans les `params` envoyés à Brevo pour la génération des emails. Brevo interprète sa propre syntaxe de template (`{{ params.xxx }}`) côté serveur, ce qui permet l'exécution de ce payload dans leur moteur : une SSTI côté Brevo, alimentée par nos données.

## Correctif

Tous les emails transitent par un point de passage unique : `Brevo.send_email()` dans `recoco/apps/communication/brevo.py`. On y ajoute `sanitize_brevo_params()`, qui parcourt récursivement le dict/list de `params` et casse toute séquence `{{`/`}}` en y insérant un espace de largeur nulle (invisible à l'affichage), avant construction du `SendSmtpEmail`.

Ce point unique couvre tous les appelants actuels (notes, commentaires, invitations, digests, noms/organisations utilisateur...) sans avoir à modifier chaque site d'appel.

## Tests

Ajout de tests dans `test_brevo.py` : sanitizer isolé, récursion sur structures imbriquées, et intégration complète via `Brevo.send_email` avec un payload `{{7*7}}`. Suite `test_brevo.py` (9) et `test_api.py` (10) passent sans régression.