### PR TITLE
fix(sécu): restreindre les champs modifiables via PATCH /api/projects/<id>/

### DIFF
--- a/recoco/apps/projects/serializers.py
+++ b/recoco/apps/projects/serializers.py
@@ -156,6 +156,24 @@ class ProjectSerializer(
         return nh3.clean(value)
 
 
+class ProjectLocationSerializer(BaseSerializerMixin, serializers.ModelSerializer):
+    """Restricted write serializer for the Project PATCH endpoint.
+
+    Used for callers who only hold `projects.change_location` (any project
+    collaborator, draft or not — see `COLLABORATOR_DRAFT_PERMISSIONS`/
+    `COLLABORATOR_PERMISSIONS`) so that only `location` is writable.
+    `name`/`description`/`tags`/etc. stay reserved for advisors, who hold
+    `projects.change_project`/`projects.use_project_tags`, matching the
+    classic (non-REST) views. Prevents mass assignment (security audit
+    finding #12).
+    """
+
+    class Meta:
+        model = Project
+        fields = ["id", "location"]
+        read_only_fields = ["id"]
+
+
 class UserProjectSerializer(ProjectSerializer):
     class Meta(ProjectSerializer.Meta):
         fields = ProjectSerializer.Meta.fields + [

--- a/recoco/apps/projects/serializers.py
+++ b/recoco/apps/projects/serializers.py
@@ -160,12 +160,11 @@ class ProjectLocationSerializer(BaseSerializerMixin, serializers.ModelSerializer
     """Restricted write serializer for the Project PATCH endpoint.
 
     Used for callers who only hold `projects.change_location` (any project
-    collaborator, draft or not — see `COLLABORATOR_DRAFT_PERMISSIONS`/
+    collaborator, draft or not -> see `COLLABORATOR_DRAFT_PERMISSIONS`/
     `COLLABORATOR_PERMISSIONS`) so that only `location` is writable.
     `name`/`description`/`tags`/etc. stay reserved for advisors, who hold
     `projects.change_project`/`projects.use_project_tags`, matching the
-    classic (non-REST) views. Prevents mass assignment (security audit
-    finding #12).
+    classic (non-REST) views.
     """
 
     class Meta:

--- a/recoco/apps/projects/tests/test_rest.py
+++ b/recoco/apps/projects/tests/test_rest.py
@@ -782,6 +782,68 @@ def test_project_advisors_note_cannot_be_updated_by_project_patch_api(
     assert project_draft.advisors_note != new_note
 
 
+@pytest.mark.django_db
+def test_project_draft_collaborator_cannot_mass_assign_privileged_fields_via_patch_api(
+    request, api_client, project_draft
+):
+    """Regression test for security audit finding #12 (mass assignment).
+
+    A draft-stage collaborator only holds `projects.change_location` (see
+    `COLLABORATOR_DRAFT_PERMISSIONS`), which is enough to pass the PATCH
+    endpoint's single permission check. The endpoint must not let that low
+    privilege also rewrite name/description/is_diagnostic_done, which the
+    classic (non-REST) views reserve for advisors via `change_project`.
+    """
+    user = baker.make(auth_models.User, email="collaborator@example.com")
+    utils.assign_collaborator(user, project_draft)
+
+    original_name = project_draft.name
+    original_description = project_draft.description
+    assert project_draft.is_diagnostic_done is False
+
+    api_client.force_authenticate(user)
+
+    url = reverse("projects-detail", args=[project_draft.id])
+    response = api_client.patch(
+        url,
+        data={
+            "name": "hijacked name",
+            "description": "hijacked description",
+            "is_diagnostic_done": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.data["name"] == original_name
+    assert response.data["description"] == original_description
+    assert response.data["is_diagnostic_done"] is False
+
+    project_draft.refresh_from_db()
+    assert project_draft.name == original_name
+    assert project_draft.description == original_description
+    assert project_draft.is_diagnostic_done is False
+
+
+@pytest.mark.django_db
+def test_project_draft_collaborator_can_still_update_location_via_patch_api(
+    request, api_client, project_draft
+):
+    """A draft-stage collaborator still has legitimate use of their
+    `change_location` permission: it must keep working on its own field."""
+    user = baker.make(auth_models.User, email="collaborator@example.com")
+    utils.assign_collaborator(user, project_draft)
+
+    api_client.force_authenticate(user)
+
+    url = reverse("projects-detail", args=[project_draft.id])
+    response = api_client.patch(url, data={"location": "new address"})
+
+    assert response.status_code == 200
+
+    project_draft.refresh_from_db()
+    assert project_draft.location == "new address"
+
+
 ################
 # Project Site Status
 ################

--- a/recoco/apps/projects/tests/test_rest.py
+++ b/recoco/apps/projects/tests/test_rest.py
@@ -844,6 +844,31 @@ def test_project_draft_collaborator_can_still_update_location_via_patch_api(
     assert project_draft.location == "new address"
 
 
+@pytest.mark.django_db
+def test_project_collaborator_cannot_update_location_of_another_project_via_patch_api(
+    request, api_client, project_draft, make_project
+):
+    """`projects.change_location` is an object-level (django-guardian)
+    permission granted per project a user actually collaborates on — it
+    must not let them touch a project they aren't a member of."""
+    other_project = make_project()
+
+    user = baker.make(auth_models.User, email="collaborator@example.com")
+    utils.assign_collaborator(user, project_draft)
+
+    original_location = other_project.location
+
+    api_client.force_authenticate(user)
+
+    url = reverse("projects-detail", args=[other_project.id])
+    response = api_client.patch(url, data={"location": "hijacked address"})
+
+    assert response.status_code == 403
+
+    other_project.refresh_from_db()
+    assert other_project.location == original_location
+
+
 ################
 # Project Site Status
 ################

--- a/recoco/apps/projects/tests/test_rest.py
+++ b/recoco/apps/projects/tests/test_rest.py
@@ -26,7 +26,7 @@ from pytest_django.asserts import assertContains
 from recoco import verbs
 from recoco.apps.conversations import models as conversations_models
 from recoco.apps.tasks import models as tasks_models
-from recoco.utils import login
+from recoco.utils import get_group_for_site, login
 
 from .. import models, utils
 from ..models import Document
@@ -754,6 +754,69 @@ def test_project_is_updated_by_project_patch_api(request, api_client, project_dr
 
     project_draft.refresh_from_db()
     assert project_draft.name == new_name
+
+
+@pytest.mark.django_db
+def test_project_advisor_without_assignment_cannot_patch_project_api(
+    request, api_client, project_draft
+):
+    """`sites.list_projects` is granted to every member of the site's
+    `advisor` group, regardless of any relation to a specific project. It
+    must not let such a user bypass the endpoint's object-level permission
+    check for a project they aren't assigned to at all.
+    """
+    with login(api_client, groups=["example_com_advisor"]):
+        url = reverse("projects-detail", args=[project_draft.id])
+        response = api_client.patch(url, data={"name": "Hacked name"})
+
+    assert response.status_code == 403
+
+    project_draft.refresh_from_db()
+    assert project_draft.name != "Hacked name"
+
+
+@pytest.mark.django_db
+def test_project_advisor_group_member_without_change_project_cannot_mass_assign_via_patch_api(
+    request, api_client, project_draft
+):
+    """
+    A user can hold object-level `projects.change_location` on a project
+    (e.g. as a collaborator) while also being a member of the site's
+    `advisor` group (`sites.list_projects`). That site-wide membership must
+    not escalate them to the full write serializer: only object-level
+    `projects.change_project` should, matching the classic (non-REST)
+    views.
+    """
+    site = get_current_site(request)
+    user = baker.make(auth_models.User, email="collaborator@example.com")
+    utils.assign_collaborator(user, project_draft)
+    user.groups.add(get_group_for_site("advisor", site))
+
+    original_name = project_draft.name
+    original_description = project_draft.description
+    assert project_draft.is_diagnostic_done is False
+
+    api_client.force_authenticate(user)
+
+    url = reverse("projects-detail", args=[project_draft.id])
+    response = api_client.patch(
+        url,
+        data={
+            "name": "hijacked name",
+            "description": "hijacked description",
+            "is_diagnostic_done": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.data["name"] == original_name
+    assert response.data["description"] == original_description
+    assert response.data["is_diagnostic_done"] is False
+
+    project_draft.refresh_from_db()
+    assert project_draft.name == original_name
+    assert project_draft.description == original_description
+    assert project_draft.is_diagnostic_done is False
 
 
 @pytest.mark.django_db

--- a/recoco/apps/projects/views/rest.py
+++ b/recoco/apps/projects/views/rest.py
@@ -55,6 +55,7 @@ from ..serializers import (
     DocumentSerializer,
     NewDocumentSerializer,
     ProjectForListSerializer,
+    ProjectLocationSerializer,
     ProjectSiteSerializer,
     TopicSerializer,
     UserProjectSerializer,
@@ -123,18 +124,30 @@ class ProjectDetail(
             request.user, "projects.change_location", p
         )  # need at least one write perm
         context = {"request": request, "view": self, "format": format}
-        serializer = UserProjectSerializer(
+
+        # Only advisors/observers hold `change_project` (and, together with
+        # it, `use_project_tags` — see `ADVISOR_PERMISSIONS`); collaborators,
+        # draft or not, only ever hold `change_location`. Restrict the
+        # writable fields to match, closing a mass-assignment gap (security
+        # audit finding #12).
+        write_serializer_class = (
+            UserProjectSerializer
+            if has_perm(request.user, "list_projects", request.site)
+            or has_perm(request.user, "projects.change_project", p)
+            else ProjectLocationSerializer
+        )
+        write_serializer = write_serializer_class(
             p, context=context, data=request.data, partial=True
         )
-        if serializer.is_valid():
+        if write_serializer.is_valid():
             # old = copy(p)
-            serializer.save()
+            write_serializer.save()
             # if new:
             #     signals.project_project_updated.send(
             #         sender=self, old_one=old, new_one=new
             #     )
-            return Response(serializer.data)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            return Response(UserProjectSerializer(p, context=context).data)
+        return Response(write_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
 class ProjectList(ListAPIView):

--- a/recoco/apps/projects/views/rest.py
+++ b/recoco/apps/projects/views/rest.py
@@ -120,20 +120,17 @@ class ProjectDetail(
 
     def patch(self, request, pk, format=None):
         p = self.get_object(pk)
-        has_perm(request.user, "list_projects", request.site) or has_perm_or_403(
-            request.user, "projects.change_location", p
-        )  # need at least one write perm
+
+        # The minimal perm required to allow a PATCH
+        has_perm_or_403(request.user, "projects.change_location", p)
         context = {"request": request, "view": self, "format": format}
 
         # Only advisors/observers hold `change_project` (and, together with
-        # it, `use_project_tags` — see `ADVISOR_PERMISSIONS`); collaborators,
-        # draft or not, only ever hold `change_location`. Restrict the
-        # writable fields to match, closing a mass-assignment gap (security
-        # audit finding #12).
+        # it, `use_project_tags` -> see `ADVISOR_PERMISSIONS`).
+        # Collaborators, draft or not, only hold `change_location`.
         write_serializer_class = (
             UserProjectSerializer
-            if has_perm(request.user, "list_projects", request.site)
-            or has_perm(request.user, "projects.change_project", p)
+            if has_perm(request.user, "projects.change_project", p)
             else ProjectLocationSerializer
         )
         write_serializer = write_serializer_class(


### PR DESCRIPTION
## Contexte

Suite à l'audit de sécurité (item 12), l'API `PATCH /api/projects/<id>/` ne vérifiait qu'une seule permission (`projects.change_location`) pour autoriser la modification de *tous* les champs exposés par le serializer, y compris `name`, `description`, `is_diagnostic_done` et `tags` — des champs que les vues classiques réservent aux conseillers via `change_project`/`use_project_tags`.

Un collaborateur simple (y compris en brouillon) pouvait donc modifier ces champs alors qu'il n'y a normalement pas accès.

## Correctif

Un serializer restreint (`ProjectLocationSerializer`, champ `location` uniquement) est utilisé pour les appelants qui n'ont pas `projects.change_project` ; le serializer complet reste utilisé pour les conseillers/modérateurs.

## Tests

Ajout de tests de non-régression dans `test_rest.py` :
- un collaborateur sans `change_project` ne peut pas modifier `name`/`description`/`is_diagnostic_done` (champs ignorés silencieusement, comme pour `advisors_note`)
- il peut toujours modifier `location`, seul champ couvert par sa permission