### PR TITLE
fix(projects): bloque la modification d'un projet par un conseiller non affecté

### DIFF
--- a/recoco/apps/projects/tests/test_rest.py
+++ b/recoco/apps/projects/tests/test_rest.py
@@ -757,6 +757,20 @@ def test_project_is_updated_by_project_patch_api(request, api_client, project_dr
 
 
 @pytest.mark.django_db
+def test_project_advisor_without_assignment_cannot_patch_project_api(
+    request, api_client, project_draft
+):
+    with login(api_client, groups=["example_com_advisor"]):
+        url = reverse("projects-detail", args=[project_draft.id])
+        response = api_client.patch(url, data={"name": "Hacked name"})
+
+    assert response.status_code == 403
+
+    project_draft.refresh_from_db()
+    assert project_draft.name != "Hacked name"
+
+
+@pytest.mark.django_db
 def test_project_advisors_note_cannot_be_updated_by_project_patch_api(
     request, api_client, project_draft
 ):

--- a/recoco/apps/projects/views/rest.py
+++ b/recoco/apps/projects/views/rest.py
@@ -119,9 +119,7 @@ class ProjectDetail(
 
     def patch(self, request, pk, format=None):
         p = self.get_object(pk)
-        has_perm(request.user, "list_projects", request.site) or has_perm_or_403(
-            request.user, "projects.change_location", p
-        )  # need at least one write perm
+        has_perm_or_403(request.user, "projects.change_location", p)
         context = {"request": request, "view": self, "format": format}
         serializer = UserProjectSerializer(
             p, context=context, data=request.data, partial=True


### PR DESCRIPTION
Problème identifié : N'importe quel conseiller (advisor) du site pouvait modifier n'importe quel projet du site, y compris ceux sur lesquels il n'a aucune affectation (ni membre, ni observateur, ni conseiller assigné).

Correctif:
  - recoco/apps/projects/views/rest.py : patch() ne vérifie plus que la permission objet projects.change_location, accordée uniquement aux utilisateurs réellement affectés au projet (membre, conseiller, observateur).

+ Test de régression ajouté